### PR TITLE
Call safeGuard(Entity) as Consumer

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/display/RealDisplayItem.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/display/RealDisplayItem.java
@@ -257,8 +257,7 @@ public class RealDisplayItem extends AbstractDisplayItem {
             return;
         }
         this.guardedIstack = AbstractDisplayItem.createGuardItemStack(this.originalItemStack, this.shop);
-        this.item = this.shop.getLocation().getWorld().dropItem(getDisplayLocation(), this.guardedIstack);
-        safeGuard(this.item);
+        this.item = this.shop.getLocation().getWorld().dropItem(getDisplayLocation(), this.guardedIstack, this::safeGuard);
         new ShopDisplayItemSafeGuardEvent(shop, this.item).callEvent();
     }
 


### PR DESCRIPTION
This calls the safeGuard(Entity) method as Consumer when calling World#dropItem. By doing this, all the relevant changes are applied to the Item **before** it's actually spawned. It doesn't really make sense to spawn an item with default properties, just to change them in the same tick immediately after the ItemSpawnEvent has been called.

**Advantages:**
Plugins that listen to EntitySpawnEvent or ItemSpawnEvent can see the final properties of the spawned item. They will for example immediately see that the pickup delay is set to Integer.MAX_VALUE. This makes it compatible with plugins like my Drop2InventoryPlus.

**Disadvantages:**
None.