### PR TITLE
Fix datetime reads & Remove duplicate try-with-resource statements

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
@@ -93,11 +93,11 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
                 .selectColumns("locale")
                 .build()
                 .executeAsync(sqlQuery -> {
-                            try (ResultSet set = sqlQuery.getResultSet()) {
-                                if (set.next()) {
-                                    callback.accept(Optional.of(set.getString("locale")));
-                                }
+                            ResultSet set = sqlQuery.getResultSet();
+                            if (set.next()) {
+                                callback.accept(Optional.of(set.getString("locale")));
                             }
+
                         }, (exception, sqlAction) -> {
                             callback.accept(Optional.empty());
                             plugin.getLogger().log(Level.WARNING, "Failed to get player locale! SQL:" + sqlAction.getSQLContent(), exception);
@@ -164,7 +164,8 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
                 .createQuery()
                 .addCondition("key", "database_version")
                 .selectColumns("value")
-                .build().execute(); ResultSet result = query.getResultSet()) {
+                .build().execute();) {
+            ResultSet result = query.getResultSet();
             if (!result.next()) {
                 return 0;
             }
@@ -211,7 +212,8 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
     public DataRecord getDataRecord(long dataId) throws SQLException {
         try (SQLQuery query = DataTables.DATA.createQuery()
                 .addCondition("id", dataId)
-                .build().execute(); ResultSet result = query.getResultSet()) {
+                .build().execute();) {
+            ResultSet result = query.getResultSet();
             if (result.next()) {
                 return new SimpleDataRecord(result);
             }
@@ -272,7 +274,8 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
                 .addCondition("x", x)
                 .addCondition("y", y)
                 .addCondition("z", z)
-                .build().execute(); ResultSet result = query.getResultSet()) {
+                .build().execute();) {
+            ResultSet result = query.getResultSet();
             if (result.next()) {
                 return result.getInt("shop");
             } else {
@@ -288,7 +291,8 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
     public long locateShopDataId(long shopId) {
         try (SQLQuery query = DataTables.SHOPS.createQuery()
                 .addCondition("id", shopId)
-                .build().execute(); ResultSet result = query.getResultSet()) {
+                .build().execute()) {
+            ResultSet result = query.getResultSet();
             if (result.next()) {
                 return result.getInt("data");
             } else {
@@ -367,7 +371,8 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             builder.addCondition(entry.getKey(), entry.getValue());
         }
-        try (SQLQuery query = builder.build().execute(); ResultSet set = query.getResultSet()) {
+        try (SQLQuery query = builder.build().execute()) {
+            ResultSet set = query.getResultSet();
             if (set.next()) {
                 int id = set.getInt("id");
                 Log.debug("Found data record with id " + id + " for record " + simpleDataRecord);
@@ -603,7 +608,8 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
         plugin.getLogger().info("Performing query for data downloading (" + name + ")...");
         if (hasTable(getPrefix() + tableLegacyName + "_" + actionId)) {
             try (SQLQuery query = manager.createQuery().inTable(getPrefix() + tableLegacyName + "_" + actionId)
-                    .build().execute(); ResultSet set = query.getResultSet()) {
+                    .build().execute()) {
+                ResultSet set = query.getResultSet();
                 int count = 0;
                 while (set.next()) {
                     target.add(clazz.getConstructor(ResultSet.class).newInstance(set));

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/bean/SimpleDataRecord.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/bean/SimpleDataRecord.java
@@ -62,7 +62,7 @@ public class SimpleDataRecord implements DataRecord {
         this.extra = set.getString("extra");
         this.inventorySymbolLink = set.getString("inv_symbol_link");
         this.inventoryWrapper = set.getString("inv_wrapper");
-        this.createTime = set.getDate("create_time");
+        this.createTime = set.getTimestamp("create_time");
     }
 
     @Override

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
@@ -84,7 +84,8 @@ public class ShopLoader {
         int valid = 0;
         List<Shop> pendingLoading = new ArrayList<>();
 
-        try (SQLQuery warpRS = plugin.getDatabaseHelper().selectAllShops(); ResultSet rs = warpRS.getResultSet()) {
+        try (SQLQuery warpRS = plugin.getDatabaseHelper().selectAllShops()) {
+            ResultSet rs = warpRS.getResultSet();
             Timer timer = new Timer();
             timer.start();
             boolean deleteCorruptShops = plugin.getConfig().getBoolean("debug.delete-corrupt-shops", false);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/MsgUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/MsgUtil.java
@@ -184,7 +184,8 @@ public class MsgUtil {
      */
     public static void loadTransactionMessages() {
         OUTGOING_MESSAGES.clear(); // Delete old messages
-        try (SQLQuery warpRS = plugin.getDatabaseHelper().selectAllMessages(); ResultSet rs = warpRS.getResultSet()) {
+        try (SQLQuery warpRS = plugin.getDatabaseHelper().selectAllMessages()) {
+            ResultSet rs = warpRS.getResultSet();
             while (rs.next()) {
                 String owner = rs.getString("receiver");
                 UUID ownerUUID;


### PR DESCRIPTION
At the beginning of the design of EasySQL, the Autoclosing of `Connection`, `Statement` and `ResultSet` has been considered and closed together in `SQLQuery#close`.

So you don't have to use _`try-with-resources`_ or close anything but the `SQLQuery` by yourself, to prevent the code from getting complicated and hard to read.

By the way, all `executeAsync(@Nullable usage, @Nullable ex)` queries will be closed after handled, and the first value cloud be null if you don't need to do anything.

If you want to change the default exception handler, just use `SQLManager#setExceptionHandler(handler)`. 