### PR TITLE
Improve makeExportBackup method

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -1003,7 +1003,7 @@ public class Util {
     @SneakyThrows
     public static void makeExportBackup(@Nullable String backupName) {
         if (StringUtils.isEmpty(backupName)) {
-            backupName = "export-" + QuickShop.getFork() + QuickShop.getVersion()  + "-" + ".txt";
+            backupName = "export-" + QuickShop.getFork() + "-" + QuickShop.getVersion()+ ".txt";
         }
         File file = new File(plugin.getDataFolder(), backupName);
         if (file.exists()) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -1003,13 +1003,17 @@ public class Util {
     @SneakyThrows
     public static void makeExportBackup(@Nullable String backupName) {
         if (StringUtils.isEmpty(backupName)) {
-            backupName = "export.txt";
+            backupName = "export-" + QuickShop.getFork() + QuickShop.getVersion()  + "-" + ".txt";
         }
-        File file = new File(plugin.getDataFolder(), backupName + ".txt");
+        File file = new File(plugin.getDataFolder(), backupName);
         if (file.exists()) {
             Files.move(file.toPath(), new File(file.getParentFile(), file.getName() + UUID.randomUUID().toString().replace("-", "")).toPath());
         }
-        file.createNewFile();
+        
+        if(!file.createNewFile()) {
+            plugin.getLogger().warning("Failed to create new backup file!");
+            return;
+        }
 
         plugin.getLogger().log(Level.WARNING, "Backup hadn't available in this version yet!");
 
@@ -1020,6 +1024,7 @@ public class Util {
 //                    .forEach((shop -> finalReport.append(shop).append("\n")));
 //            try (BufferedWriter outputStream = new BufferedWriter(new FileWriter(file, false))) {
 //                outputStream.write(finalReport.toString());
+//                plugin.getLogger().info("Successfully created file " + backupName);
 //            } catch (IOException exception) {
 //                plugin.getLogger().log(Level.WARNING, "Backup failed", exception);
 //            }


### PR DESCRIPTION
Updates the `makeExportBackup` method in the following ways:

- Removed extra `.txt` file which resulted in files such as `export.txt.txt`
- Changed default file name to now be `export-<fork>-<version>.txt`, allowing more clear info about what version created the file.
- Put `createNewFile` into an if-check to return an error message when file creation failed
- Added a log message informing about the created backup file with the name used.