### PR TITLE
Added Velocity Compatibility Module

### DIFF
--- a/compatibility/velocity/.gitignore
+++ b/compatibility/velocity/.gitignore
@@ -1,0 +1,113 @@
+# User-specific stuff
+.idea/
+
+*.iml
+*.ipr
+*.iws
+
+# IntelliJ
+out/
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+target/
+
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+.flattened-pom.xml
+
+# Common working directory
+run/

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ghostchu</groupId>
+        <artifactId>quickshop-hikari</artifactId>
+        <version>3.4.0.1</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <groupId>com.ghostchu.quickshop.compatibility</groupId>
+    <artifactId>velocity</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Compat-Velocity</name>
+
+    <description>Compatibility module for Velocity</description>
+    <properties>
+        <java.version>16</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>net/kyori/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>3.1.2-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>3.1.2-SNAPSHOT</version>
+            <type>javadoc</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/compatibility/velocity/src/main/java/com/ghostchu/compatibility/velocity/Main.java
+++ b/compatibility/velocity/src/main/java/com/ghostchu/compatibility/velocity/Main.java
@@ -1,0 +1,111 @@
+package com.ghostchu.compatibility.velocity;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.PostOrder;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.DisconnectEvent;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
+import com.velocitypowered.api.event.player.PlayerChatEvent;
+import com.velocitypowered.api.event.player.ServerPostConnectEvent;
+import com.velocitypowered.api.event.player.ServerPreConnectEvent;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public final class Main {
+    private static final MinecraftChannelIdentifier QUICKSHOP_BUNGEE_CHANNEL = MinecraftChannelIdentifier.create("quickshop", "bungee");
+    private static final String SUB_CHANNEL_FORWARD = "forward";
+    private static final String SUB_CHANNEL_COMMAND = "command";
+    private static final String CHAT_COMMAND_REQUEST = "request";
+    private static final String CHAT_COMMAND_CANCEL = "cancel";
+    private final Set<UUID> pendingForward = Collections.synchronizedSet(new HashSet<>());
+
+    @Inject
+    private ProxyServer proxy;
+
+    @Subscribe
+    public void onProxyInitialization(ProxyInitializeEvent event) {
+        proxy.getChannelRegistrar().register(QUICKSHOP_BUNGEE_CHANNEL);
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        this.pendingForward.clear();
+        proxy.getChannelRegistrar().unregister(QUICKSHOP_BUNGEE_CHANNEL);
+    }
+
+    @Subscribe
+    public void on(PluginMessageEvent event) {
+        if (!QUICKSHOP_BUNGEE_CHANNEL.equals(event.getIdentifier())) {
+            return;
+        }
+        ByteArrayDataInput in = event.dataAsDataStream();
+        String subChannel = in.readUTF();
+        if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
+            // the receiver is a server when the proxy talks to a server
+            if (event.getSource() instanceof ServerConnection) {
+                String command = in.readUTF();
+                processCommand(command, in);
+            }
+        }
+    }
+
+    private void processCommand(String command, ByteArrayDataInput in) {
+        UUID uuid = UUID.fromString(in.readUTF());
+        switch (command) {
+            case CHAT_COMMAND_REQUEST -> this.pendingForward.add(uuid);
+            case CHAT_COMMAND_CANCEL -> this.pendingForward.remove(uuid);
+        }
+    }
+
+    private void forwardMessage(Player player, String message) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF(SUB_CHANNEL_FORWARD);
+        out.writeUTF(message);
+        player.getCurrentServer().ifPresent(server ->
+            server.sendPluginMessage(QUICKSHOP_BUNGEE_CHANNEL, message.getBytes())
+        );
+    }
+
+    @Subscribe(order = PostOrder.FIRST)
+    public void onChat(PlayerChatEvent event) {
+        Player player = event.getPlayer();
+        // Workaround against kicking of players with valid signed key and client 1.19.1 or higher by velocity
+        if (player.getIdentifiedKey() != null
+                && player.getProtocolVersion().equals(ProtocolVersion.MINECRAFT_1_19_1)) {
+            return;
+        }
+        UUID uuid = player.getUniqueId();
+        if (pendingForward.contains(uuid)) {
+            forwardMessage(player, event.getMessage());
+            event.setResult(PlayerChatEvent.ChatResult.denied());
+        }
+    }
+
+    @Subscribe(order = PostOrder.FIRST)
+    public void onDisconnect(DisconnectEvent event) {
+        pendingForward.remove(event.getPlayer().getUniqueId());
+    }
+
+    @Subscribe(order = PostOrder.FIRST)
+    public void onServerSwitch(ServerPreConnectEvent event) {
+        pendingForward.remove(event.getPlayer().getUniqueId());
+    }
+
+    @Subscribe(order = PostOrder.FIRST)
+    public void onServerKick(ServerPostConnectEvent event) {
+        pendingForward.remove(event.getPlayer().getUniqueId());
+    }
+}

--- a/compatibility/velocity/src/main/java/com/ghostchu/compatibility/velocity/Main.java
+++ b/compatibility/velocity/src/main/java/com/ghostchu/compatibility/velocity/Main.java
@@ -82,15 +82,15 @@ public final class Main {
     @Subscribe(order = PostOrder.FIRST)
     public void onChat(PlayerChatEvent event) {
         Player player = event.getPlayer();
-        // Workaround against kicking of players with valid signed key and client 1.19.1 or higher by velocity
-        if (player.getIdentifiedKey() != null
-                && player.getProtocolVersion().equals(ProtocolVersion.MINECRAFT_1_19_1)) {
-            return;
-        }
         UUID uuid = player.getUniqueId();
         if (pendingForward.contains(uuid)) {
             forwardMessage(player, event.getMessage());
-            event.setResult(PlayerChatEvent.ChatResult.denied());
+            // Workaround against kicking of players with valid signed key and client 1.19.1 or higher by velocity
+            ProtocolVersion protocol = player.getProtocolVersion();
+            if (player.getIdentifiedKey() == null || !protocol.equals(ProtocolVersion.MINECRAFT_1_19_1)) {
+                event.setResult(PlayerChatEvent.ChatResult.denied());
+            }
+
         }
     }
 

--- a/compatibility/velocity/src/main/resources/velocity-plugin.json
+++ b/compatibility/velocity/src/main/resources/velocity-plugin.json
@@ -4,7 +4,8 @@
   "version": "${project.version}",
   "description": "Compatibility module for Velocity",
   "authors": [
-    "Ghost_chu"
+    "Ghost_chu",
+    "4drian3d"
   ],
   "main": "com.ghostchu.quickshop.compatibility.${project.artifactId}.Main"
 }

--- a/compatibility/velocity/src/main/resources/velocity-plugin.json
+++ b/compatibility/velocity/src/main/resources/velocity-plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "qscompat-${project.artifactId}",
+  "name": "qscompat-${project.artifactId}",
+  "version": "${project.version}",
+  "description": "Compatibility module for Velocity",
+  "authors": [
+    "Ghost_chu"
+  ],
+  "main": "com.ghostchu.quickshop.compatibility.${project.artifactId}.Main"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,7 @@
         <module>quickshop-bukkit</module>
         <module>compatibility/common</module>
         <module>compatibility/bungeecord</module>
+        <module>compatibility/velocity</module>
         <module>compatibility/clearlag</module>
         <module>compatibility/nocheatplus</module>
         <module>compatibility/worldguard</module>


### PR DESCRIPTION
Implemented Quickshop Velocity Compatibility Module 

*Currently Minecraft clients who have version 1.19.1/2 and have a valid signed key are kicked if their chat message is modified or cancelled, so I put a workaround to "ignore" those players to prevent them from being banned.*

Otherwise, this is a port of the bungee compatibility module to the velocity api