### PR TITLE
5.0.0.2

### DIFF
--- a/addon/bluemap/pom.xml
+++ b/addon/bluemap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discordsrv/pom.xml
+++ b/addon/discordsrv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discount/pom.xml
+++ b/addon/discount/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/displaycontrol/pom.xml
+++ b/addon/displaycontrol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/dynmap/pom.xml
+++ b/addon/dynmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/limited/pom.xml
+++ b/addon/limited/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/list/pom.xml
+++ b/addon/list/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/plan/pom.xml
+++ b/addon/plan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/shopitemonly/pom.xml
+++ b/addon/shopitemonly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/compatibility/advancedregionmarket/pom.xml
+++ b/compatibility/advancedregionmarket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bentobox/pom.xml
+++ b/compatibility/bentobox/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord-geyser/pom.xml
+++ b/compatibility/bungeecord-geyser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord/pom.xml
+++ b/compatibility/bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/clearlag/pom.xml
+++ b/compatibility/clearlag/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/elitemobs/pom.xml
+++ b/compatibility/elitemobs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/griefprevention/pom.xml
+++ b/compatibility/griefprevention/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/openinv/pom.xml
+++ b/compatibility/openinv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/plotsquared/pom.xml
+++ b/compatibility/plotsquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/residence/pom.xml
+++ b/compatibility/residence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/superiorskyblock/pom.xml
+++ b/compatibility/superiorskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldedit/pom.xml
+++ b/compatibility/worldedit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldguard/pom.xml
+++ b/compatibility/worldguard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/crowdin/lang/th-TH/messages.yml
+++ b/crowdin/lang/th-TH/messages.yml
@@ -182,18 +182,18 @@ unknown-player: <red>Target player doesn't exist, please check the username you 
 player-offline: <red>The target player currently is offline.
 player-profile-format: <aqua>{0}</aqua><gold>(<yellow>{1}</yellow>)
 shop-type:
-  selling: SELLING
-  buying: BUYING
+  selling: ขาย
+  buying: ซื้อ
 language:
-  qa-issues: '<yellow>Quality assurance issues: <aqua>{0}%'
+  qa-issues: '<yellow>ปัญหาการประกันคุณภาพ: <aqua>{0}%'
   code: '<yellow>โค้ด: <gold>{0}'
-  approval-progress: '<yellow>Approval Progress: <aqua>{0}%'
+  approval-progress: '<yellow>ความคืบหน้าการอนุมัติ: <aqua>{0}%'
   translate-progress: '<yellow>ความคืบหน้าของการแปลภาษา: <aqua>{0}%'
   name: '<yellow>ชื่อ: <gold>{0}'
   help-us: <green>[ช่วยพวกเราแปลภาษา]
 warn-to-paste: |-
-  <yellow>Collecting data and uploading to Pastebin. This may take a while...
-  <red><bold>Warning:</bold> The data is kept public for one week! It may leak your server configuration and other sensitive information. Make sure you only send it to <bold>trusted staff/developers.
+  <yellow>รวบรวมข้อมูลและอัปโหลดไปยัง Pastebin การดําเนินการนี้อาจใช้เวลาสักครู่...
+  <red><bold>คำเตือน:</bold> ข้อมูลจะถูกเก็บไว้สู่สาธารณะเป็นเวลาหนึ่งสัปดาห์! อาจทําให้การกําหนดค่าเซิร์ฟเวอร์และข้อมูลที่ละเอียดอ่อนอื่น ๆ ของคุณรั่วไหล ตรวจสอบให้แน่ใจว่าคุณส่งไปที่ <bold>พนักงาน/นักพัฒนาที่เชื่อถือได้
 how-many-sell-stack: <green>Enter in chat, how many bulk you wish to <light_purple>SELL</light_purple>. There are <yellow>{0}<green> items per bulk and you can sell <yellow>{1}</yellow> bulks. Enter <aqua>{2}</aqua> in chat to sell all.
 updatenotify:
   buttontitle: '[Update Now]'

--- a/platform/quickshop-platform-interface/pom.xml
+++ b/platform/quickshop-platform-interface/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-abstract/pom.xml
+++ b/platform/quickshop-platform-spigot-abstract/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu</groupId>
     <artifactId>quickshop-hikari</artifactId>
-    <version>5.0.0.1</version>
+    <version>5.0.0.2</version>
     <packaging>pom</packaging>
     <name>quickshop-hikari</name>
     <description>Another QuickShop fork</description>

--- a/quickshop-api/pom.xml
+++ b/quickshop-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
     </parent>
 
     <artifactId>quickshop-bukkit</artifactId>

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
@@ -72,6 +72,10 @@ public class SubCommand_Debug implements CommandHandler<CommandSender> {
         if (split.length > 1) {
             value = split[1];
         }
+        if(!key.startsWith("com.ghostchu.quickshop") && !key.startsWith("quickshop")){
+            sender.sendMessage("Error: You can only set the quickshop related properties for safety.");
+            return;
+        }
         if (value == null) {
             System.clearProperty(key);
             sender.sendMessage("Property " + key + " has been deleted.");

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
@@ -48,7 +48,36 @@ public class SubCommand_Debug implements CommandHandler<CommandSender> {
             case "check-shop-status" -> handleShopDebug(sender, subParams);
             case "toggle-shop-load-status" -> handleShopLoading(sender, subParams);
             case "check-shop-debug" -> handleShopInfo(sender, subParams);
+            case "set-property" -> handleProperty(sender, subParams);
             default -> plugin.text().of(sender, "debug.arguments-invalid", parser.getArgs().get(0)).send();
+        }
+    }
+
+    private void handleProperty(CommandSender sender, List<String> subParams) {
+        if (subParams.isEmpty()) {
+            sender.sendMessage("Error: You must enter a property key=value set.");
+            return;
+        }
+        if (subParams.size() > 1) {
+            sender.sendMessage("Error: You must enter a (and only one) property key=value set. E.g   aaa=bbb");
+            return;
+        }
+        String[] split = subParams.get(0).split("=");
+        if (split.length < 1) {
+            sender.sendMessage("Error: You must enter a (and only one) property key=value set. E.g   aaa=bbb");
+            return;
+        }
+        String key = split[0];
+        String value = null;
+        if (split.length > 1) {
+            value = split[1];
+        }
+        if (value == null) {
+            System.clearProperty(key);
+            sender.sendMessage("Property " + key + " has been deleted.");
+        } else {
+            String oldOne = System.setProperty(key, value);
+            sender.sendMessage("Property " + key + " has been changed from " + oldOne + " to " + value);
         }
     }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/ChunkListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/ChunkListener.java
@@ -39,13 +39,11 @@ public class ChunkListener extends AbstractQSListener {
         }
         cleanDisplayItems(e.getChunk());
         String chunkName = e.getChunk().getWorld().getName() + ", X=" + e.getChunk().getX() + ", Z=" + e.getChunk().getZ();
-        Bukkit.getScheduler().runTaskLater(plugin.getJavaPlugin(), () -> {
-            try (PerfMonitor ignored = new PerfMonitor("Load shops in chunk [" + chunkName + "]", Duration.of(2, ChronoUnit.SECONDS))) {
-                for (Shop shop : inChunk.values()) {
-                    plugin.getShopManager().loadShop(shop);
-                }
+        try (PerfMonitor ignored = new PerfMonitor("Load shops in chunk [" + chunkName + "]", Duration.of(500, ChronoUnit.MILLIS))) {
+            for (Shop shop : inChunk.values()) {
+                plugin.getShopManager().loadShop(shop);
             }
-        }, 1);
+        }
     }
 
     private void cleanDisplayItems(Chunk chunk) {
@@ -69,7 +67,7 @@ public class ChunkListener extends AbstractQSListener {
             return;
         }
         for (Shop shop : inChunk.values()) {
-            try (PerfMonitor ignored = new PerfMonitor("Unload shops in chunk " + e.getChunk(), Duration.of(2, ChronoUnit.SECONDS))) {
+            try (PerfMonitor ignored = new PerfMonitor("Unload shops in chunk " + e.getChunk(), Duration.of(500, ChronoUnit.MILLIS))) {
                 if (shop.isLoaded()) {
                     plugin.getShopManager().unloadShop(shop);
                 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -833,7 +833,7 @@ public class SimpleShopManager implements ShopManager, Reloadable {
      */
     @Override
     public @Nullable Shop getShop(@NotNull Location loc, boolean skipShopableChecking) {
-        if (!skipShopableChecking) {
+        if (!skipShopableChecking && !Util.canBeShop(loc.getBlock())) {
             return null;
         }
         final Map<Location, Shop> inChunk = getShops(loc.getChunk());

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -833,7 +833,7 @@ public class SimpleShopManager implements ShopManager, Reloadable {
      */
     @Override
     public @Nullable Shop getShop(@NotNull Location loc, boolean skipShopableChecking) {
-        if (!skipShopableChecking && !Util.canBeShop(loc.getBlock())) {
+        if (!skipShopableChecking && !Util.isShoppables(loc.getBlock().getType())) {
             return null;
         }
         final Map<Location, Shop> inChunk = getShops(loc.getChunk());

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -833,7 +833,7 @@ public class SimpleShopManager implements ShopManager, Reloadable {
      */
     @Override
     public @Nullable Shop getShop(@NotNull Location loc, boolean skipShopableChecking) {
-        if (!skipShopableChecking && !Util.isShoppables(loc.getBlock().getType())) {
+        if (!skipShopableChecking) {
             return null;
         }
         final Map<Location, Shop> inChunk = getShops(loc.getChunk());

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/display/virtual/VirtualDisplayItem.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/display/virtual/VirtualDisplayItem.java
@@ -152,19 +152,16 @@ public class VirtualDisplayItem extends AbstractDisplayItem implements Reloadabl
         Chunk chunk = shop.getLocation().getChunk();
         chunkLocation = new SimpleShopChunk(chunk.getWorld().getName(), chunk.getX(), chunk.getZ());
         manager.put(chunkLocation, this);
-        if (Util.isLoaded(shop.getLocation())) {
-            //Let nearby player can saw fake item
-            List<Player> onlinePlayers = new ArrayList<>(Bukkit.getOnlinePlayers());
-            onlinePlayers.removeIf(p -> !p.getWorld().equals(shop.getLocation().getWorld()));
-            for (Player onlinePlayer : onlinePlayers) {
-                double distance = onlinePlayer.getLocation().distance(shop.getLocation());
-                if (Math.abs(distance) > Bukkit.getViewDistance() * 16) {
-                    Log.debug("Skipped for player " + onlinePlayer.getName() + " because distance is " + distance);
-                    continue;
-                }
-                if (isApplicableForPlayer(onlinePlayer)) { // TODO: Refactor with better way
-                    packetSenders.add(onlinePlayer.getUniqueId());
-                }
+        //Let nearby player can saw fake item
+        List<Player> onlinePlayers = new ArrayList<>(Bukkit.getOnlinePlayers());
+        onlinePlayers.removeIf(p -> !p.getWorld().equals(shop.getLocation().getWorld()));
+        for (Player onlinePlayer : onlinePlayers) {
+            double distance = onlinePlayer.getLocation().distance(shop.getLocation());
+            if (Math.abs(distance) > Bukkit.getViewDistance() * 16) {
+                continue;
+            }
+            if (isApplicableForPlayer(onlinePlayer)) { // TODO: Refactor with better way
+                packetSenders.add(onlinePlayer.getUniqueId());
             }
         }
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/PackageUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/PackageUtil.java
@@ -13,7 +13,7 @@ public class PackageUtil {
      */
     @NotNull
     public static PackageUtil.SysPropertiesParseResult parsePackageProperly(@NotNull String name) {
-        Log.Caller caller = Log.Caller.create();
+        Log.Caller caller = Log.Caller.createSync();
         String str = caller.getClassName() + "." + name;
         String value = System.getProperty(str);
         SysPropertiesParseResult result = new SysPropertiesParseResult(str, value);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -49,6 +49,7 @@ import java.lang.management.ManagementFactory;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -275,7 +276,7 @@ public class Util {
      */
     @Deprecated(forRemoval = true)
     public static void debugLog(@NotNull String... logs) {
-        Log.Caller caller = Log.Caller.create();
+        CompletableFuture<Log.Caller> caller = Log.Caller.create();
         for (String log : logs) {
             Log.debug(Level.INFO, log, caller);
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/logger/Log.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/logger/Log.java
@@ -315,6 +315,9 @@ public class Log {
 
         @NotNull
         public static CompletableFuture<Caller> create(int steps) {
+            if("true".equalsIgnoreCase(System.getProperty("quickshop-hikari-disable-debug-logger"))){
+                return CompletableFuture.supplyAsync(()->new Caller("<DISABLED>","<DISABLED>","<DISABLED>",-1));
+            }
             Throwable throwable = new Throwable("Caller Check");
             return CompletableFuture.supplyAsync(() -> {
                 StackTraceElement[] caller = throwable.getStackTrace();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/logger/Log.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/logger/Log.java
@@ -1,6 +1,8 @@
 package com.ghostchu.quickshop.util.logger;
 
 import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.common.util.CommonUtil;
+import com.ghostchu.quickshop.common.util.QuickExecutor;
 import com.ghostchu.quickshop.common.util.Timer;
 import com.ghostchu.quickshop.util.Util;
 import com.google.common.collect.EvictingQueue;
@@ -16,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 
@@ -35,7 +38,7 @@ public class Log {
     }
 
     @ApiStatus.Internal
-    public static void cron(@NotNull Level level, @NotNull String message, @Nullable Caller caller) {
+    public static void cron(@NotNull Level level, @NotNull String message, @Nullable CompletableFuture<Caller> caller) {
         LOCK.writeLock().lock();
         try {
             Record recordEntry;
@@ -53,9 +56,11 @@ public class Log {
     }
 
     private static void debugStdOutputs(Record recordEntry) {
-        if (Util.isDevMode()) {
-            QuickShop.getInstance().logger().info("[DEBUG] " + recordEntry.toString());
-        }
+        recordEntry.generate().thenAccept(log->{
+            if (Util.isDevMode()) {
+                QuickShop.getInstance().logger().info("[DEBUG] " + log);
+            }
+        });
     }
 
     public static void cron(@NotNull Level level, @NotNull String message) {
@@ -67,7 +72,7 @@ public class Log {
     }
 
     @ApiStatus.Internal
-    public static void debug(@NotNull Level level, @NotNull String message, @Nullable Caller caller) {
+    public static void debug(@NotNull Level level, @NotNull String message, @Nullable CompletableFuture<Caller> caller) {
         LOCK.writeLock().lock();
         try {
             Record recordEntry;
@@ -87,7 +92,7 @@ public class Log {
         debug(level, message, Caller.create());
     }
 
-    public static void performance(@NotNull Level level, @NotNull String message, @NotNull Caller caller) {
+    public static void performance(@NotNull Level level, @NotNull String message, @NotNull CompletableFuture<Caller> caller) {
         LOCK.writeLock().lock();
         try {
             Record recordEntry = new Record(level, Type.PERFORMANCE, message, caller);
@@ -150,7 +155,7 @@ public class Log {
     }
 
     @ApiStatus.Internal
-    public static void permission(@NotNull Level level, @NotNull String message, @Nullable Caller caller) {
+    public static void permission(@NotNull Level level, @NotNull String message, @Nullable CompletableFuture<Caller> caller) {
         LOCK.writeLock().lock();
         try {
             Record recordEntry;
@@ -176,7 +181,7 @@ public class Log {
     }
 
     @ApiStatus.Internal
-    public static void timing(@NotNull Level level, @NotNull String operation, @NotNull Timer timer, @Nullable Caller caller) {
+    public static void timing(@NotNull Level level, @NotNull String operation, @NotNull Timer timer, @Nullable CompletableFuture<Caller> caller) {
         LOCK.writeLock().lock();
         try {
             Record recordEntry;
@@ -198,7 +203,7 @@ public class Log {
     }
 
     @ApiStatus.Internal
-    public static void transaction(@NotNull Level level, @NotNull String message, @Nullable Caller caller) {
+    public static void transaction(@NotNull Level level, @NotNull String message, @Nullable CompletableFuture<Caller> caller) {
         LOCK.writeLock().lock();
         try {
             Record recordEntry;
@@ -238,54 +243,51 @@ public class Log {
         @NotNull
         private final String message;
         @Nullable
-        private final Caller caller;
-        @Nullable
-        private String toStringCache;
+        private final CompletableFuture<Caller> caller;
 
-        public Record(@NotNull Level level, @NotNull Type type, @NotNull String message, @Nullable Caller caller) {
+        public Record(@NotNull Level level, @NotNull Type type, @NotNull String message, @Nullable CompletableFuture<Caller> caller) {
             this.level = level;
             this.type = type;
             this.message = message;
             this.caller = caller;
         }
 
-        @Override
-        public String toString() {
-            if (toStringCache != null) {
-                return toStringCache;
-            }
-            StringBuilder sb = new StringBuilder();
-            Log.Caller caller = this.getCaller();
-
-            if (caller != null) {
-                String simpleClassName = caller.getClassName().substring(caller.getClassName().lastIndexOf('.') + 1);
-                sb.append("[");
-                sb.append(caller.getThreadName());
-                sb.append("/");
-                sb.append(this.getLevel().getName());
-                sb.append("]");
-                sb.append(" ");
-                sb.append("(");
-                sb.append(simpleClassName).append("#").append(caller.getMethodName()).append(":").append(caller.getLineNumber());
-                sb.append(")");
-                sb.append(" ");
-            } else {
-                sb.append("[");
-                sb.append(this.getLevel().getName());
-                sb.append("]");
-                sb.append(" ");
-            }
-            sb.append(this.getMessage());
-            toStringCache = sb.toString();
-            return toStringCache;
+        public CompletableFuture<String> generate() {
+            return CompletableFuture.supplyAsync(() -> {
+                StringBuilder sb = new StringBuilder();
+                Log.Caller caller;
+                if (this.caller == null) {
+                    caller = new Caller("<NO RECORDING>", "<NO RECORDING>", "<NO RECORDING>", -1);
+                } else {
+                    caller = this.caller.join();
+                }
+                if (caller != null) {
+                    String simpleClassName = caller.getClassName().substring(caller.getClassName().lastIndexOf('.') + 1);
+                    sb.append("[");
+                    sb.append(caller.getThreadName());
+                    sb.append("/");
+                    sb.append(this.getLevel().getName());
+                    sb.append("]");
+                    sb.append(" ");
+                    sb.append("(");
+                    sb.append(simpleClassName).append("#").append(caller.getMethodName()).append(":").append(caller.getLineNumber());
+                    sb.append(")");
+                    sb.append(" ");
+                } else {
+                    sb.append("[");
+                    sb.append(this.getLevel().getName());
+                    sb.append("]");
+                    sb.append(" ");
+                }
+                sb.append(this.getMessage());
+                return sb.toString();
+            }, QuickExecutor.getCommonExecutor());
         }
 
     }
 
     @Data
     public final static class Caller {
-        @NotNull
-        private static final StackWalker STACK_WALKER = StackWalker.getInstance(Set.of(StackWalker.Option.RETAIN_CLASS_REFERENCE), 3);
         @NotNull
         private final String threadName;
         @NotNull
@@ -302,24 +304,27 @@ public class Log {
         }
 
         @NotNull
-        public static Caller create() {
+        public static CompletableFuture<Caller> create() {
             return create(3);
         }
 
         @NotNull
-        public static Caller createRaw() {
-            return create(2);
+        public static Caller createSync() {
+            return create(3).join();
         }
 
         @NotNull
-        public static Caller create(int steps) {
-            List<StackWalker.StackFrame> caller = STACK_WALKER.walk(frames -> frames.limit(steps + 1L).toList());
-            StackWalker.StackFrame frame = caller.get(steps);
-            String threadName = Thread.currentThread().getName();
-            String className = frame.getClassName();
-            String methodName = frame.getMethodName();
-            int codeLine = frame.getLineNumber();
-            return new Caller(threadName, className, methodName, codeLine);
+        public static CompletableFuture<Caller> create(int steps) {
+            Throwable throwable = new Throwable("Caller Check");
+            return CompletableFuture.supplyAsync(() -> {
+                StackTraceElement[] caller = throwable.getStackTrace();
+                StackTraceElement frame = caller[steps];
+                String threadName = Thread.currentThread().getName();
+                String className = frame.getClassName();
+                String methodName = frame.getMethodName();
+                int codeLine = frame.getLineNumber();
+                return new Caller(threadName, className, methodName, codeLine);
+            }, QuickExecutor.getCommonExecutor());
         }
     }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/performance/PerfMonitor.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/performance/PerfMonitor.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public class PerfMonitor implements AutoCloseable {
@@ -13,23 +14,9 @@ public class PerfMonitor implements AutoCloseable {
     private final Instant startTime;
     @Nullable
     private final Duration exceptedDuration;
-    private final Log.Caller caller;
+    private final CompletableFuture<Log.Caller> caller;
     @Nullable
     private String context;
-
-    public PerfMonitor() {
-        this.caller = Log.Caller.create();
-        this.name = caller.getClassName() + "#" + caller.getMethodName();
-        this.startTime = Instant.now();
-        this.exceptedDuration = null;
-    }
-
-    public PerfMonitor(@NotNull Duration exceptedDuration) {
-        this.caller = Log.Caller.create();
-        this.name = caller.getClassName() + "#" + caller.getMethodName();
-        this.startTime = Instant.now();
-        this.exceptedDuration = exceptedDuration;
-    }
 
     public PerfMonitor(@NotNull String name) {
         this.caller = Log.Caller.create();
@@ -63,6 +50,7 @@ public class PerfMonitor implements AutoCloseable {
     public void setContext(@Nullable String context) {
         this.context = context;
     }
+
 
     @Override
     public void close() {

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.0.0.1</version>
+        <version>5.0.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
**4.x to 5.x is a major breaking update, read the 5.x main-changelog [here](https://github.com/Ghost-chu/QuickShop-Hikari/releases/tag/5.0.0.0) before upgrading from 4.x to 5.**
## New Feature

* New `/qs debug set-property <key-value>` sub command to dynamically change the JVM property.
  * For safety, you're only able to change the quickshop related properties.

## Improved

* Improved background debug logger
  * From `0.1329ms` per record to `0.0061ms` per record by moving cost tasks into a async executor, it improved the performance on busy server when there have LOTS of debug logs on server main thread.
  * By set `-Dquickshop-hikari-disable-debug-logger=true` will able to disable the debug logger's stack trace completely when you running a huge server, but remember you will need re-enable it before reporting the bugs/errors to us.
