### PR TITLE
5.1.1.0

### DIFF
--- a/addon/bluemap/pom.xml
+++ b/addon/bluemap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/bluemap/pom.xml
+++ b/addon/bluemap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discordsrv/pom.xml
+++ b/addon/discordsrv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discordsrv/pom.xml
+++ b/addon/discordsrv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discount/pom.xml
+++ b/addon/discount/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discount/pom.xml
+++ b/addon/discount/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/displaycontrol/pom.xml
+++ b/addon/displaycontrol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/displaycontrol/pom.xml
+++ b/addon/displaycontrol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/dynmap/pom.xml
+++ b/addon/dynmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/dynmap/pom.xml
+++ b/addon/dynmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/limited/pom.xml
+++ b/addon/limited/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/limited/pom.xml
+++ b/addon/limited/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/list/pom.xml
+++ b/addon/list/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/list/pom.xml
+++ b/addon/list/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/plan/pom.xml
+++ b/addon/plan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/plan/pom.xml
+++ b/addon/plan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/reremake-migrator/pom.xml
+++ b/addon/reremake-migrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/reremake-migrator/pom.xml
+++ b/addon/reremake-migrator/pom.xml
@@ -80,6 +80,12 @@
             <version>2.11.3</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.21.9</version>
+            <scope>compile</scope>
+        </dependency>
         <!--        <dependency>-->
         <!--            <groupId>net.kyori</groupId>-->
         <!--            <artifactId>adventure-text-serializer-plain</artifactId>-->

--- a/addon/reremake-migrator/pom.xml
+++ b/addon/reremake-migrator/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ghostchu</groupId>
+        <artifactId>quickshop-hikari</artifactId>
+        <version>5.1.0.1</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <groupId>com.ghostchu.quickshop.addon</groupId>
+    <artifactId>reremake-migrator</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Addon-Reremake-Migrator</name>
+
+    <description>Migrator QuickShop-Reremake data to QuickShop-Hikari</description>
+    <properties>
+        <java.version>17</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>quickshop-repo</id>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.ghostchu</groupId>
+            <artifactId>quickshop-bukkit</artifactId>
+            <version>${parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.13.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.maxgamer</groupId>
+            <artifactId>QuickShop</artifactId>
+            <version>5.1.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.tr7zw</groupId>
+            <artifactId>item-nbt-api-plugin</artifactId>
+            <version>2.11.3</version>
+            <scope>compile</scope>
+        </dependency>
+        <!--        <dependency>-->
+        <!--            <groupId>net.kyori</groupId>-->
+        <!--            <artifactId>adventure-text-serializer-plain</artifactId>-->
+        <!--            <version>4.12.0</version>-->
+        <!--            <scope>provided</scope>-->
+        <!--        </dependency>-->
+    </dependencies>
+</project>

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/Main.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/Main.java
@@ -3,9 +3,14 @@ package com.ghostchu.quickshop.addon.reremakemigrator;
 import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.addon.reremakemigrator.command.SubCommand_ReremakeMigrate;
 import com.ghostchu.quickshop.api.command.CommandContainer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -13,6 +18,7 @@ public class Main extends JavaPlugin implements Listener {
     static Main instance;
     private QuickShop hikari;
     private org.maxgamer.quickshop.QuickShop reremake;
+    private String deniedMessage;
     @Override
     public void onLoad() {
         instance = this;
@@ -47,5 +53,20 @@ public class Main extends JavaPlugin implements Listener {
 
     public org.maxgamer.quickshop.QuickShop getReremake() {
         return reremake;
+    }
+
+    public void setDeniedMessage(String deniedMessage) {
+        this.deniedMessage = deniedMessage;
+    }
+
+    public void setDeniedMessage(Component deniedMessage) {
+        this.deniedMessage = LegacyComponentSerializer.legacySection().serialize(deniedMessage);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerJoin(AsyncPlayerPreLoginEvent event){
+        if(this.deniedMessage != null){
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, this.deniedMessage);
+        }
     }
 }

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/Main.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/Main.java
@@ -1,0 +1,51 @@
+package com.ghostchu.quickshop.addon.reremakemigrator;
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.addon.reremakemigrator.command.SubCommand_ReremakeMigrate;
+import com.ghostchu.quickshop.api.command.CommandContainer;
+import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class Main extends JavaPlugin implements Listener {
+    static Main instance;
+    private QuickShop hikari;
+    private org.maxgamer.quickshop.QuickShop reremake;
+    @Override
+    public void onLoad() {
+        instance = this;
+    }
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        hikari = QuickShop.getInstance();
+        reremake = org.maxgamer.quickshop.QuickShop.getInstance();
+        getLogger().info("Found QuickShop-Hikari: "+hikari.getJavaPlugin().getDescription().getVersion());
+        getLogger().info("Found QuickShop-Reremake: "+reremake.getDescription().getVersion());
+        Bukkit.getPluginManager().registerEvents(this, this);
+        hikari.getCommandManager().registerCmd(
+                CommandContainer
+                        .builder()
+                        .prefix("migratefromreremake")
+                        .description((locale) -> hikari.text().of("addon.reremake-migrator.commands.migratefromreremake").forLocale(locale))
+                        .permission("quickshopaddon.reremakemigrator.migrator-admin")
+                        .executor(new SubCommand_ReremakeMigrate(this, hikari,reremake))
+                        .build());
+    }
+
+    @Override
+    public void onDisable() {
+        HandlerList.unregisterAll((Plugin) this);
+    }
+
+    public QuickShop getHikari() {
+        return hikari;
+    }
+
+    public org.maxgamer.quickshop.QuickShop getReremake() {
+        return reremake;
+    }
+}

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/command/SubCommand_ReremakeMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/command/SubCommand_ReremakeMigrate.java
@@ -1,0 +1,59 @@
+package com.ghostchu.quickshop.addon.reremakemigrator.command;
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.addon.reremakemigrator.Main;
+import com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent.ConfigMigrate;
+import com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent.MigrateComponent;
+import com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent.ShopMigrate;
+import com.ghostchu.quickshop.api.command.CommandHandler;
+import com.ghostchu.quickshop.api.command.CommandParser;
+import com.ghostchu.quickshop.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.command.ConsoleCommandSender;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class SubCommand_ReremakeMigrate implements CommandHandler<ConsoleCommandSender> {
+    private final Main plugin;
+    private final QuickShop hikari;
+    private final org.maxgamer.quickshop.QuickShop reremake;
+    private final AtomicBoolean running =  new AtomicBoolean(false);
+
+    public SubCommand_ReremakeMigrate(Main main, QuickShop hikari, org.maxgamer.quickshop.QuickShop reremake) {
+        this.plugin = main;
+        this.hikari = hikari;
+        this.reremake = reremake;
+    }
+
+    @Override
+    public void onCommand(ConsoleCommandSender sender, @NotNull String commandLabel, @NotNull CommandParser parser) {
+        if(running.get()){
+            return;
+        }
+        if (parser.getArgs().isEmpty()) {
+            hikari.text().of(sender, "command-incorrect", "/quickshop reremakemigrate <shouldOverrideExistShops>").send();
+            return;
+        }
+        if(!Bukkit.getOnlinePlayers().isEmpty()){
+            hikari.text().of(sender, "addon.reremake-migrator.server-not-empty").send();
+            return;
+        }
+        boolean shouldOverrideExistShops = Boolean.parseBoolean(parser.getArgs().get(0));
+        List<MigrateComponent> migrateComponentList = new ArrayList<>();
+        migrateComponentList.add(new ConfigMigrate(plugin, hikari,reremake, sender));
+        migrateComponentList.add(new ShopMigrate(plugin, hikari,reremake, sender, shouldOverrideExistShops));
+        Util.asyncThreadRun(()->{
+            running.set(true);
+            int count = 0;
+            for (MigrateComponent migrateComponent : migrateComponentList) {
+                count++;
+                hikari.text().of(sender, "addon.reremake-migrator.executing", migrateComponent.getClass().getSimpleName(),count, migrateComponentList.size()).send();
+                migrateComponent.migrate();
+            }
+            running.set(false);
+        });
+    }
+}

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/AbstractMigrateComponent.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/AbstractMigrateComponent.java
@@ -1,0 +1,35 @@
+package com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent;
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.QuickShopBukkit;
+import com.ghostchu.quickshop.addon.reremakemigrator.Main;
+
+public abstract class AbstractMigrateComponent implements MigrateComponent {
+    private final Main plugin;
+    private final QuickShop hikari;
+    private final org.maxgamer.quickshop.QuickShop reremake;
+
+    public AbstractMigrateComponent(Main main, QuickShop hikari, org.maxgamer.quickshop.QuickShop reremake){
+        this.plugin = main;
+        this.hikari = hikari;
+        this.reremake = reremake;
+    }
+    @Override
+    public QuickShop getHikari() {
+        return this.hikari;
+    }
+
+    @Override
+    public QuickShopBukkit getHikariJavaPlugin() {
+        return this.hikari.getJavaPlugin();
+    }
+
+    @Override
+    public org.maxgamer.quickshop.QuickShop getReremake() {
+        return this.reremake;
+    }
+    @Override
+    public Main getPlugin() {
+        return plugin;
+    }
+}

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
@@ -20,9 +20,8 @@ public class ConfigMigrate extends AbstractMigrateComponent {
             "game-language", "enabled-languages", "mojangapi-mirror", "dev-mode", "tax", "tax-account", "unlimited-shop-owner-change",
             "unlimited-shop-owner-change-account", "show-tax", "respect-item-flag", "currency", "logging", "trying-fix-banlance-insuffient",
             "include-offlineplayer-list", "economy-type", "use-decimal-format", "decimal-format", "send-display-item-protection-alert",
-            "send-shop-protection-alert", "chat-type", "database.mysql", "database.host", "database.port", "database.user",
-            "database.password", "database.prefix", "database.usessl", "limits", "shop-block", "shop.cost", "shop.refund"
-            , "shop.sending-stock-message-to-staffs", "shop.disable-creative-mode-trading", "shop.disable-super-tool",
+            "send-shop-protection-alert", "chat-type", "limits", "shop-block", "shop.cost", "shop.refund",
+            "shop.sending-stock-message-to-staffs", "shop.disable-creative-mode-trading", "shop.disable-super-tool",
             "shop.allow-owner-break-shop-sign", "shop.price-change-requires-fee", "shop.fee-for-price-change", "shop.lock",
             "shop.disable-quick-create", "shop.auto-sign", "shop.sign-glowing", "shop.sign-dye-color", "shop.pay-unlimited-shop-owners",
             "shop.display-items", "shop.display-items-check-ticks", "shop.display-type", "shop.display-auto-despawn",
@@ -57,7 +56,7 @@ public class ConfigMigrate extends AbstractMigrateComponent {
     }
 
     private void migratePriceRestrictions() {
-        getHikari().text().of(sender, "addon.reremake-migrator.modules.config.migrate-price-restriction");
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.config.migrate-price-restriction").send();
         File configFile = new File(getHikariJavaPlugin().getDataFolder(), "price-restriction.yml");
         if (!configFile.exists()) {
             try {
@@ -101,9 +100,9 @@ public class ConfigMigrate extends AbstractMigrateComponent {
 
 
     private void copyValues() {
-        getHikari().text().of(sender, "addon.reremake-migrator.modules.config.copy-values", DIRECT_COPY_KEYS.length);
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.config.copy-values", DIRECT_COPY_KEYS.length).send();
         for (int i = 0; i < DIRECT_COPY_KEYS.length; i++) {
-            getHikari().text().of(sender, "addon.reremake-migrator.modules.config.copy-values", (i + 1), DIRECT_COPY_KEYS.length);
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.config.copying-value", DIRECT_COPY_KEYS[i], (i + 1), DIRECT_COPY_KEYS.length).send();
             copyValue(DIRECT_COPY_KEYS[i]);
         }
         getHikariJavaPlugin().saveConfig();

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
@@ -55,7 +55,9 @@ public class ConfigMigrate extends AbstractMigrateComponent {
 
     private void migrateCommandAlias() {
         List<String> commandAlias = getReremake().getConfig().getStringList("custom-commands");
-        commandAlias.add("qs");
+        if(!commandAlias.contains("qs")){
+            commandAlias.add("qs");
+        }
         getHikari().getConfig().set("custom-commands", commandAlias);
         getHikariJavaPlugin().saveConfig();
     }
@@ -119,6 +121,8 @@ public class ConfigMigrate extends AbstractMigrateComponent {
     }
 
     private void copyValue(String keyName) {
-        getHikari().getConfig().set(keyName, getReremake().getConfig().get(keyName));
+        if (getReremake().getConfig().contains(keyName)) {
+            getHikari().getConfig().set(keyName, getReremake().getConfig().get(keyName));
+        }
     }
 }

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
@@ -47,9 +47,17 @@ public class ConfigMigrate extends AbstractMigrateComponent {
     @Override
     public boolean migrate() {
         copyValues();
+        migrateCommandAlias();
         migratePriceRestrictions();
         setFixedConfigValues();
         return true;
+    }
+
+    private void migrateCommandAlias() {
+        List<String> commandAlias = getReremake().getConfig().getStringList("custom-commands");
+        commandAlias.add("qs");
+        getHikari().getConfig().set("custom-commands", commandAlias);
+        getHikariJavaPlugin().saveConfig();
     }
 
     private void setFixedConfigValues() {

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
@@ -1,0 +1,115 @@
+package com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent;
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.addon.reremakemigrator.Main;
+import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.UUID;
+
+public class ConfigMigrate extends AbstractMigrateComponent {
+    // tax-free-for-unlimited-shop
+    //
+    private final String[] DIRECT_COPY_KEYS = new String[]{
+            "game-language", "enabled-languages", "mojangapi-mirror", "dev-mode", "tax", "tax-account", "unlimited-shop-owner-change",
+            "unlimited-shop-owner-change-account", "show-tax", "respect-item-flag", "currency", "logging", "trying-fix-banlance-insuffient",
+            "include-offlineplayer-list", "economy-type", "use-decimal-format", "decimal-format", "send-display-item-protection-alert",
+            "send-shop-protection-alert", "chat-type", "database.mysql", "database.host", "database.port", "database.user",
+            "database.password", "database.prefix", "database.usessl", "limits", "shop-block", "shop.cost", "shop.refund"
+            , "shop.sending-stock-message-to-staffs", "shop.disable-creative-mode-trading", "shop.disable-super-tool",
+            "shop.allow-owner-break-shop-sign", "shop.price-change-requires-fee", "shop.fee-for-price-change", "shop.lock",
+            "shop.disable-quick-create", "shop.auto-sign", "shop.sign-glowing", "shop.sign-dye-color", "shop.pay-unlimited-shop-owners",
+            "shop.display-items", "shop.display-items-check-ticks", "shop.display-type", "shop.display-auto-despawn",
+            "shop.display-despawn-range", "shop.display-check-time", "shop.display-allow-stacks", "shop.finding", "shop.alternate-currency-symbol",
+            "shop.alternate-currency-symbol-list", "shop.disable-vault-format", "shop.currency-symbol-on-right", "shop.ignore-unlimited-shop-messages",
+            "shop.auto-fetch-shop-messages", "shop.ignore-cancel-chat-event", "shop.allow-shop-without-space-for-sign",
+            "shop.maximum-digits-in-price", "shop.show-owner-uuid-in-controlpanel-if-op", "shop.sign-material",
+            "shop.use-enchantment-for-enchanted-book", "shop.use-effect-for-potion-item", "shop.blacklist-world",
+            "shop.blacklist-lores", "shop.protection-checking", "shop.protection-checking-blacklist", "shop.protection-checking-listener-blacklist",
+            "shop.max-shops-checks-in-once", "shop.display-item-use-name", "shop.update-sign-when-inventory-moving", "shop.allow-economy-loan",
+            "shop.word-for-trade-all-items", "shop.ongoing-fee", "shop.force-load-downgrade-items", "shop.remove-protection-trigger",
+            "shop.allow-stacks", "shop.force-use-item-original-name", "blacklist", "plugin.Multiverse-Core", "plugin.WorldEdit",
+            "effect", "matcher", "protect.explode", "protect.hopper", "protect.entity", "custom-item-stacksize", "purge", "debug"
+    };
+    private final CommandSender sender;
+
+    public ConfigMigrate(Main main, QuickShop hikari, org.maxgamer.quickshop.QuickShop reremake, CommandSender sender) {
+        super(main, hikari, reremake);
+        this.sender = sender;
+    }
+
+    @Override
+    public boolean migrate() {
+        copyValues();
+        migratePriceRestrictions();
+        setFixedConfigValues();
+        return true;
+    }
+
+    private void setFixedConfigValues() {
+        getHikari().getConfig().set("legacy-updater.shop-sign", true);
+    }
+
+    private void migratePriceRestrictions() {
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.config.migrate-price-restriction");
+        File configFile = new File(getHikariJavaPlugin().getDataFolder(), "price-restriction.yml");
+        if (!configFile.exists()) {
+            try {
+                Files.copy(getHikariJavaPlugin().getResource("price-restriction.yml"), configFile.toPath());
+            } catch (IOException e) {
+                getHikari().logger().warn("Failed to copy price-restriction.yml.yml to plugin folder!", e);
+            }
+        }
+        FileConfiguration configuration = YamlConfiguration.loadConfiguration(configFile);
+        configuration.set("undefined.min", getReremake().getConfig().get("shop.minimum-price", "0.01"));
+        configuration.set("undefined.max", getReremake().getConfig().get("shop.maximum-price", "999999999999999999999999999999.99"));
+        configuration.set("enable", true);
+        configuration.set("whole-number-only", getReremake().getConfig().get("shop.whole-number-prices-only"));
+        List<String> str = getReremake().getConfig().getStringList("shop.price-restriction");
+        int count = 0;
+        for (String record : str) {
+            count++;
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.migrate-price-restriction-entry", count, str.size()).send();
+            try {
+                String[] records = record.split(";");
+                if (records.length != 3) continue;
+                Material material = Material.matchMaterial(records[0]);
+                double min = Double.parseDouble(records[1]);
+                double max = Double.parseDouble(records[2]);
+                String name = UUID.randomUUID().toString().replace("-", "");
+                if (material == null) continue;
+                configuration.set("rules." + name + ".items", List.of(material));
+                configuration.set("rules." + name + ".currency", List.of("*"));
+                configuration.set("rules." + name + ".min", min);
+                configuration.set("rules." + name + ".max", max);
+            } catch (Exception e) {
+                getHikari().logger().warn("Failed to migrate rule {}", record, e);
+            }
+        }
+        try {
+            configuration.save(configFile);
+        } catch (IOException e) {
+            getHikari().logger().warn("Failed to save the price-restriction.yml", e);
+        }
+    }
+
+
+    private void copyValues() {
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.config.copy-values", DIRECT_COPY_KEYS.length);
+        for (int i = 0; i < DIRECT_COPY_KEYS.length; i++) {
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.config.copy-values", (i + 1), DIRECT_COPY_KEYS.length);
+            copyValue(DIRECT_COPY_KEYS[i]);
+        }
+        getHikariJavaPlugin().saveConfig();
+    }
+
+    private void copyValue(String keyName) {
+        getHikari().getConfig().set(keyName, getReremake().getConfig().get(keyName));
+    }
+}

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/MigrateComponent.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/MigrateComponent.java
@@ -1,0 +1,13 @@
+package com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent;
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.QuickShopBukkit;
+import com.ghostchu.quickshop.addon.reremakemigrator.Main;
+
+public interface MigrateComponent {
+    QuickShop getHikari();
+    QuickShopBukkit getHikariJavaPlugin();
+    org.maxgamer.quickshop.QuickShop getReremake();
+    boolean migrate();
+    Main getPlugin();
+}

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -100,7 +100,7 @@ public class ShopMigrate extends AbstractMigrateComponent {
             count.set(0);
             for (int i = 0; i < preparedShops.size(); i++) {
                 com.ghostchu.quickshop.api.shop.Shop shop = preparedShops.get(i);
-                getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.register-entry",shop , count, preparedShops.size()).send();
+                getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.register-entry",shop , count.incrementAndGet(), preparedShops.size()).send();
                 getHikari().getShopManager().registerShop(shop, true);
                 shop.setDirty();
             }
@@ -121,8 +121,7 @@ public class ShopMigrate extends AbstractMigrateComponent {
         }).exceptionally((error) -> {
             getHikari().logger().warn("Error while migrating shops", error);
             return null;
-        });
-
+        }).join();
         return true;
     }
 }

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -72,7 +72,7 @@ public class ShopMigrate extends AbstractMigrateComponent {
                         getHikari(),
                         -1,
                         shopLoc,
-                        reremakeShop.getPrice(),
+                        Math.min(reremakeShop.getPrice(), 999999999999999999999999999999.99),
                         reremakeShop.getItem(),
                         QUserImpl.createSync(getHikari().getPlayerFinder(), reremakeShop.getOwner()),
                         reremakeShop.isUnlimited(),

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -9,6 +9,7 @@ import com.ghostchu.quickshop.obj.QUserImpl;
 import com.ghostchu.quickshop.shop.ContainerShop;
 import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapper;
 import com.ghostchu.quickshop.util.logger.Log;
+import com.ghostchu.quickshop.util.performance.BatchBukkitExecutor;
 import com.google.common.io.Files;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ShopMigrate extends AbstractMigrateComponent {
     private final boolean override;
@@ -37,20 +39,21 @@ public class ShopMigrate extends AbstractMigrateComponent {
 
     @Override
     public boolean migrate() {
-        int count = 0;
+        final AtomicInteger count = new AtomicInteger(0);
         List<Shop> allShops = getReremake().getShopManager().getAllShops();
         List<ContainerShop> preparedShops = new ArrayList<>();
-        getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.start-migrate", allShops.size());
-        for (Shop reremakeShop : allShops) {
-            count++;
-            getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.migrate-entry", reremakeShop.toString(), count, allShops.size());
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.start-migrate", allShops.size()).send();
+        BatchBukkitExecutor<Shop> batchBukkitExecutor = new BatchBukkitExecutor<>();
+        batchBukkitExecutor.addTasks(allShops);
+        batchBukkitExecutor.startHandle(getHikari().getJavaPlugin(), reremakeShop -> {
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.migrate-entry", reremakeShop.toString(), count.incrementAndGet(), allShops.size()).send();
             try {
                 Location shopLoc = reremakeShop.getLocation();
                 com.ghostchu.quickshop.api.shop.Shop hikariShop = getHikari().getShopManager().getShop(shopLoc);
                 if (hikariShop != null) {
                     if (!override) {
                         getHikari().logger().warn("Shop conflict: Take policy skipping, next one.");
-                        continue;
+                        return;
                     } else {
                         getHikari().logger().warn("Shop conflict: Take policy overwrite, overwriting.");
                         getHikari().getShopManager().deleteShop(hikariShop);
@@ -59,11 +62,11 @@ public class ShopMigrate extends AbstractMigrateComponent {
                 BlockState block = shopLoc.getBlock().getState();
                 if (!(block instanceof Container container)) {
                     getHikari().logger().warn("Shop Invalid: Shop block not a valid Container, failed to create InventoryHolder.");
-                    continue;
+                    return;
                 }
                 ContainerShop hikariRawShop = new ContainerShop(
                         getHikari(),
-                        0,
+                        -1,
                         shopLoc,
                         reremakeShop.getPrice(),
                         reremakeShop.getItem(),
@@ -84,41 +87,41 @@ public class ShopMigrate extends AbstractMigrateComponent {
                 preparedShops.add(hikariRawShop);
             } catch (Exception e) {
                 getHikari().logger().warn("Failed to migrate shop " + reremakeShop, e);
-                return false;
             }
-        }
-        getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.unloading-reremake");
-        Bukkit.getPluginManager().disablePlugin(getReremake());
-        File reremakeDataDirectory = new File(getHikari().getDataFolder(), "QuickShop");
-        try {
-            Files.move(reremakeDataDirectory, new File(getHikari().getDataFolder(), "QuickShop.migrated"));
-        } catch (IOException e) {
-            getHikari().logger().warn("Failed to move QuickShop-Reremake data directory, it may cause issues.");
-        }
-        count = 0;
-        for (int i = 0; i < preparedShops.size(); i++) {
-            getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.register-entry", count, preparedShops.size());
-            com.ghostchu.quickshop.api.shop.Shop shop = preparedShops.get(i);
-            getHikari().getShopManager().registerShop(shop, true);
-            getHikari().getShopManager().loadShop(shop);
-            shop.setDirty();
-            shop.setSignText();
-            getHikari().getShopManager().unloadShop(shop);
-        }
-        CompletableFuture<?>[] shopsToSaveFuture = getHikari().getShopManager().getAllShops().stream().filter(com.ghostchu.quickshop.api.shop.Shop::isDirty)
-                .map(com.ghostchu.quickshop.api.shop.Shop::update)
-                .toArray(CompletableFuture[]::new);
-        getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.saving-shops", shopsToSaveFuture.length);
-        CompletableFuture.allOf(shopsToSaveFuture)
-                .thenAcceptAsync((v) -> {
-                    if (shopsToSaveFuture.length != 0) {
-                        Log.debug("Saved " + shopsToSaveFuture.length + " shops in background.");
-                    }
-                }, QuickExecutor.getShopSaveExecutor())
-                .exceptionally(e -> {
-                    getHikari().logger().warn("Error while saving shops", e);
-                    return null;
-                }).join();
+        }).thenAccept(a -> {
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.unloading-reremake").send();
+            Bukkit.getPluginManager().disablePlugin(getReremake());
+            File reremakeDataDirectory = new File(getHikari().getDataFolder(), "QuickShop");
+            try {
+                Files.move(reremakeDataDirectory, new File(getHikari().getDataFolder(), "QuickShop.migrated"));
+            } catch (IOException e) {
+                getHikari().logger().warn("Failed to move QuickShop-Reremake data directory, it may cause issues. You should manually move it to another location.");
+            }
+            count.set(0);
+            for (int i = 0; i < preparedShops.size(); i++) {
+                com.ghostchu.quickshop.api.shop.Shop shop = preparedShops.get(i);
+                getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.register-entry",shop , count, preparedShops.size()).send();
+                getHikari().getShopManager().registerShop(shop, true);
+                shop.setDirty();
+            }
+            CompletableFuture<?>[] shopsToSaveFuture = getHikari().getShopManager().getAllShops().stream().filter(com.ghostchu.quickshop.api.shop.Shop::isDirty)
+                    .map(com.ghostchu.quickshop.api.shop.Shop::update)
+                    .toArray(CompletableFuture[]::new);
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.saving-shops", shopsToSaveFuture.length).send();
+            CompletableFuture.allOf(shopsToSaveFuture)
+                    .thenAcceptAsync((v) -> {
+                        if (shopsToSaveFuture.length != 0) {
+                            Log.debug("Saved " + shopsToSaveFuture.length + " shops in background.");
+                        }
+                    }, QuickExecutor.getShopSaveExecutor())
+                    .exceptionally(e -> {
+                        getHikari().logger().warn("Error while saving shops", e);
+                        return null;
+                    }).join();
+        }).exceptionally((error) -> {
+            getHikari().logger().warn("Error while migrating shops", error);
+            return null;
+        });
 
         return true;
     }

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -131,7 +131,7 @@ public class ShopMigrate extends AbstractMigrateComponent {
 
     private void registerHikariShops(List<ContainerShop> preparedShops) {
         for (com.ghostchu.quickshop.api.shop.Shop shop : new ProgressMonitor<>(preparedShops, triple -> getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.register-entry", triple.getRight(), triple.getLeft(), triple.getMiddle()).send())) {
-            getHikari().getShopManager().registerShop(shop, true);
+            getHikari().getShopManager().registerShop(shop, true).join();
             shop.setDirty();
         }
     }

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -92,11 +92,11 @@ public class ShopMigrate extends AbstractMigrateComponent {
             } catch (Exception e) {
                 getHikari().logger().warn("Failed to migrate shop " + reremakeShop, e);
             }
-        }).thenAccept(a -> {
+        }).thenAcceptAsync(a -> {
             unloadAndMoveAwayReremake();
             registerHikariShops(preparedShops);
             saveHikariShops();
-        }).exceptionally((error) -> {
+        }, QuickExecutor.getCommonExecutor()).exceptionally((error) -> {
             getHikari().logger().warn("Error while migrating shops", error);
             success.set(false);
             return null;

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -1,0 +1,125 @@
+package com.ghostchu.quickshop.addon.reremakemigrator.migratecomponent;
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.addon.reremakemigrator.Main;
+import com.ghostchu.quickshop.api.shop.ShopType;
+import com.ghostchu.quickshop.common.util.QuickExecutor;
+import com.ghostchu.quickshop.economy.SimpleBenefit;
+import com.ghostchu.quickshop.obj.QUserImpl;
+import com.ghostchu.quickshop.shop.ContainerShop;
+import com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapper;
+import com.ghostchu.quickshop.util.logger.Log;
+import com.google.common.io.Files;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Container;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.maxgamer.quickshop.api.shop.Shop;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ShopMigrate extends AbstractMigrateComponent {
+    private final boolean override;
+    private final CommandSender sender;
+
+    public ShopMigrate(Main main, QuickShop hikari, org.maxgamer.quickshop.QuickShop reremake, CommandSender sender, boolean overrideExists) {
+        super(main, hikari, reremake);
+        this.sender = sender;
+        this.override = overrideExists;
+    }
+
+    @Override
+    public boolean migrate() {
+        int count = 0;
+        List<Shop> allShops = getReremake().getShopManager().getAllShops();
+        List<ContainerShop> preparedShops = new ArrayList<>();
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.start-migrate", allShops.size());
+        for (Shop reremakeShop : allShops) {
+            count++;
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.migrate-entry", reremakeShop.toString(), count, allShops.size());
+            try {
+                Location shopLoc = reremakeShop.getLocation();
+                com.ghostchu.quickshop.api.shop.Shop hikariShop = getHikari().getShopManager().getShop(shopLoc);
+                if (hikariShop != null) {
+                    if (!override) {
+                        getHikari().logger().warn("Shop conflict: Take policy skipping, next one.");
+                        continue;
+                    } else {
+                        getHikari().logger().warn("Shop conflict: Take policy overwrite, overwriting.");
+                        getHikari().getShopManager().deleteShop(hikariShop);
+                    }
+                }
+                BlockState block = shopLoc.getBlock().getState();
+                if (!(block instanceof Container container)) {
+                    getHikari().logger().warn("Shop Invalid: Shop block not a valid Container, failed to create InventoryHolder.");
+                    continue;
+                }
+                ContainerShop hikariRawShop = new ContainerShop(
+                        getHikari(),
+                        0,
+                        shopLoc,
+                        reremakeShop.getPrice(),
+                        reremakeShop.getItem(),
+                        QUserImpl.createSync(getHikari().getPlayerFinder(), reremakeShop.getOwner()),
+                        reremakeShop.isUnlimited(),
+                        ShopType.fromID(reremakeShop.getShopType().toID()),
+                        new YamlConfiguration(),
+                        reremakeShop.getCurrency(),
+                        reremakeShop.isDisableDisplay(),
+                        reremakeShop.getTaxAccountActual() == null ? null : QUserImpl.createSync(getHikari().getPlayerFinder(), reremakeShop.getTaxAccountActual()),
+                        getHikari().getJavaPlugin().getName(),
+                        getHikari().getInventoryWrapperManager().mklink(new BukkitInventoryWrapper(container.getInventory())),
+                        null,
+                        Collections.emptyMap(),
+                        new SimpleBenefit()
+                );
+                hikariRawShop.setDirty();
+                preparedShops.add(hikariRawShop);
+            } catch (Exception e) {
+                getHikari().logger().warn("Failed to migrate shop " + reremakeShop, e);
+                return false;
+            }
+        }
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.unloading-reremake");
+        Bukkit.getPluginManager().disablePlugin(getReremake());
+        File reremakeDataDirectory = new File(getHikari().getDataFolder(), "QuickShop");
+        try {
+            Files.move(reremakeDataDirectory, new File(getHikari().getDataFolder(), "QuickShop.migrated"));
+        } catch (IOException e) {
+            getHikari().logger().warn("Failed to move QuickShop-Reremake data directory, it may cause issues.");
+        }
+        count = 0;
+        for (int i = 0; i < preparedShops.size(); i++) {
+            getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.register-entry", count, preparedShops.size());
+            com.ghostchu.quickshop.api.shop.Shop shop = preparedShops.get(i);
+            getHikari().getShopManager().registerShop(shop, true);
+            getHikari().getShopManager().loadShop(shop);
+            shop.setDirty();
+            shop.setSignText();
+            getHikari().getShopManager().unloadShop(shop);
+        }
+        CompletableFuture<?>[] shopsToSaveFuture = getHikari().getShopManager().getAllShops().stream().filter(com.ghostchu.quickshop.api.shop.Shop::isDirty)
+                .map(com.ghostchu.quickshop.api.shop.Shop::update)
+                .toArray(CompletableFuture[]::new);
+        getHikari().text().of(sender, "addon.reremake-migrator.modules.shop.saving-shops", shopsToSaveFuture.length);
+        CompletableFuture.allOf(shopsToSaveFuture)
+                .thenAcceptAsync((v) -> {
+                    if (shopsToSaveFuture.length != 0) {
+                        Log.debug("Saved " + shopsToSaveFuture.length + " shops in background.");
+                    }
+                }, QuickExecutor.getShopSaveExecutor())
+                .exceptionally(e -> {
+                    getHikari().logger().warn("Error while saving shops", e);
+                    return null;
+                }).join();
+
+        return true;
+    }
+}

--- a/addon/reremake-migrator/src/main/resources/config.yml
+++ b/addon/reremake-migrator/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+config-version: 1

--- a/addon/reremake-migrator/src/main/resources/plugin.yml
+++ b/addon/reremake-migrator/src/main/resources/plugin.yml
@@ -1,0 +1,12 @@
+name: qsaddon-reremakemigrator
+version: '${project.version}'
+main: com.ghostchu.quickshop.addon.reremakemigrator.Main
+api-version: 1.18
+depend:
+  - QuickShop-Hikari
+  - QuickShop
+authors: [ Ghost_chu ]
+permissions:
+  quickshopaddon.reremakemigrator.migrator-admin:
+    default: op
+    description: Migrate from QuickShop-Reremake

--- a/addon/shopitemonly/pom.xml
+++ b/addon/shopitemonly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/shopitemonly/pom.xml
+++ b/addon/shopitemonly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/compatibility/advancedregionmarket/pom.xml
+++ b/compatibility/advancedregionmarket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/advancedregionmarket/pom.xml
+++ b/compatibility/advancedregionmarket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/angelchest/pom.xml
+++ b/compatibility/angelchest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/angelchest/pom.xml
+++ b/compatibility/angelchest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bentobox/pom.xml
+++ b/compatibility/bentobox/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bentobox/pom.xml
+++ b/compatibility/bentobox/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord-geyser/pom.xml
+++ b/compatibility/bungeecord-geyser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord-geyser/pom.xml
+++ b/compatibility/bungeecord-geyser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord/pom.xml
+++ b/compatibility/bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord/pom.xml
+++ b/compatibility/bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/chestprotect/pom.xml
+++ b/compatibility/chestprotect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/chestprotect/pom.xml
+++ b/compatibility/chestprotect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/clearlag/pom.xml
+++ b/compatibility/clearlag/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/clearlag/pom.xml
+++ b/compatibility/clearlag/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/elitemobs/pom.xml
+++ b/compatibility/elitemobs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/elitemobs/pom.xml
+++ b/compatibility/elitemobs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/griefprevention/pom.xml
+++ b/compatibility/griefprevention/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/griefprevention/pom.xml
+++ b/compatibility/griefprevention/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/openinv/pom.xml
+++ b/compatibility/openinv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/openinv/pom.xml
+++ b/compatibility/openinv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/plotsquared/pom.xml
+++ b/compatibility/plotsquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/plotsquared/pom.xml
+++ b/compatibility/plotsquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/residence/pom.xml
+++ b/compatibility/residence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/residence/pom.xml
+++ b/compatibility/residence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/superiorskyblock/pom.xml
+++ b/compatibility/superiorskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/superiorskyblock/pom.xml
+++ b/compatibility/superiorskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldedit/pom.xml
+++ b/compatibility/worldedit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldedit/pom.xml
+++ b/compatibility/worldedit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldguard/pom.xml
+++ b/compatibility/worldguard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldguard/pom.xml
+++ b/compatibility/worldguard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/crowdin/lang/af-ZA/messages.yml
+++ b/crowdin/lang/af-ZA/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/ar-SA/messages.yml
+++ b/crowdin/lang/ar-SA/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/bg-BG/messages.yml
+++ b/crowdin/lang/bg-BG/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/ca-ES/messages.yml
+++ b/crowdin/lang/ca-ES/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/cs-CZ/messages.yml
+++ b/crowdin/lang/cs-CZ/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/da-DK/messages.yml
+++ b/crowdin/lang/da-DK/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/de-DE/messages.yml
+++ b/crowdin/lang/de-DE/messages.yml
@@ -1435,4 +1435,4 @@ suite:
 compatibility:
   elitemobs:
     soulbound-disallowed: Du kannst Items mit Seelenverzauberung von EliteMobs nicht handeln.
-internet-paste-forbidden-privacy-reason: "<red>Failed! According your privacy setting, QuickShop-Hikari are not allowed upload your paste to Internet, turn on DIAGNOSTIC permission in privacy setting in config.yml or use <aqua>/quickshop paste --file</aqua> instead."
+internet-paste-forbidden-privacy-reason: "<red>Fehlgeschlagen! Basierend auf deinen Privatsphäre-Einstellungen ist QuickShop nicht berechtigt, deinen Paste im Internet hochzuladen. Aktiviere DIAGNOSTIC Berechtigungen in den Privatsphäre-Einstellungen in der config.yml oder verwende <aqua>/quickshop paste --file</aqua>."

--- a/crowdin/lang/de-DE/messages.yml
+++ b/crowdin/lang/de-DE/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Konnte deine Anzeigeeinstellungen nicht ändern aufgrund eines internen Fehlers. Bitte melde dies dem Serveradministrator.
     command:
       displaycontrol: <yellow>Ändere deine QuickShop Anzeige
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>Du hast erfolgreich einen Shop auf einem AdvancedChests Container erstellt!

--- a/crowdin/lang/el-GR/messages.yml
+++ b/crowdin/lang/el-GR/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/en-US/messages.yml
+++ b/crowdin/lang/en-US/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/es-ES/messages.yml
+++ b/crowdin/lang/es-ES/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/fi-FI/messages.yml
+++ b/crowdin/lang/fi-FI/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/fr-FR/messages.yml
+++ b/crowdin/lang/fr-FR/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/he-IL/messages.yml
+++ b/crowdin/lang/he-IL/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/hi-IN/messages.yml
+++ b/crowdin/lang/hi-IN/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/hu-HU/messages.yml
+++ b/crowdin/lang/hu-HU/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/it-IT/messages.yml
+++ b/crowdin/lang/it-IT/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/ja-JP/messages.yml
+++ b/crowdin/lang/ja-JP/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/ko-KR/messages.yml
+++ b/crowdin/lang/ko-KR/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/lt-LT/messages.yml
+++ b/crowdin/lang/lt-LT/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/nl-NL/messages.yml
+++ b/crowdin/lang/nl-NL/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/no-NO/messages.yml
+++ b/crowdin/lang/no-NO/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/pl-PL/messages.yml
+++ b/crowdin/lang/pl-PL/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/pt-BR/messages.yml
+++ b/crowdin/lang/pt-BR/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Falha ao alternar para mostrar ou remover o holograma de itens de loja devido a um erro interno, por favor contate um administrador.
     command:
       displaycontrol: <yellow>Alterna suas configurações para mostrar ou não os itens em cima dos baús de loja
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>Você acabou de criar um loja em um baú do AdvancedChests!

--- a/crowdin/lang/pt-PT/messages.yml
+++ b/crowdin/lang/pt-PT/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/ro-RO/messages.yml
+++ b/crowdin/lang/ro-RO/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/ru-RU/messages.yml
+++ b/crowdin/lang/ru-RU/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/sr-SP/messages.yml
+++ b/crowdin/lang/sr-SP/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/sv-SE/messages.yml
+++ b/crowdin/lang/sv-SE/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/th-TH/messages.yml
+++ b/crowdin/lang/th-TH/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/tr-TR/messages.yml
+++ b/crowdin/lang/tr-TR/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/uk-UA/messages.yml
+++ b/crowdin/lang/uk-UA/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/vi-VN/messages.yml
+++ b/crowdin/lang/vi-VN/messages.yml
@@ -1394,6 +1394,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/zh-CN/messages.yml
+++ b/crowdin/lang/zh-CN/messages.yml
@@ -1445,4 +1445,4 @@ suite:
 compatibility:
   elitemobs:
     soulbound-disallowed: 你不能交易拥有 EliteMobs 灵魂绑定附魔的物品。
-internet-paste-forbidden-privacy-reason: "<red>Failed! According your privacy setting, QuickShop-Hikari are not allowed upload your paste to Internet, turn on DIAGNOSTIC permission in privacy setting in config.yml or use <aqua>/quickshop paste --file</aqua> instead."
+internet-paste-forbidden-privacy-reason: "<red>失败！根据您的隐私设置，QuickShop-Hikari不允许将您的Paste上传到互联网，在配置文件中启用DIAGNOSTIC配置项。 或使用 <aqua>/quickshop paste --file</aqua> 代替。"

--- a/crowdin/lang/zh-CN/messages.yml
+++ b/crowdin/lang/zh-CN/messages.yml
@@ -1404,6 +1404,29 @@ addon:
     toggle-exception: <red>由于内部错误，无法切换您的悬浮物设置，请联系服务器管理员。
     command:
       displaycontrol: <yellow>切换您的 QuickShop 显示物显示
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>您已成功在 AdvancedChests 里创建了一个商店！

--- a/crowdin/lang/zh-HK/messages.yml
+++ b/crowdin/lang/zh-HK/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>Failed to toggle your display showcase settings due an internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/crowdin/lang/zh-TW/messages.yml
+++ b/crowdin/lang/zh-TW/messages.yml
@@ -1410,6 +1410,29 @@ addon:
     toggle-exception: <red>由於內部錯誤，無法切換你的懸浮物設定，請聯絡伺服器管理員。
     command:
       displaycontrol: <yellow>切換你的 QuickShop 懸浮物顯示
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/platform/quickshop-platform-interface/pom.xml
+++ b/platform/quickshop-platform-interface/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-interface/pom.xml
+++ b/platform/quickshop-platform-interface/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-abstract/pom.xml
+++ b/platform/quickshop-platform-spigot-abstract/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-abstract/pom.xml
+++ b/platform/quickshop-platform-spigot-abstract/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,7 @@
         <module>addon/dynmap</module>
         <module>addon/bluemap</module>
         <module>addon/displaycontrol</module>
+        <module>addon/reremake-migrator</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu</groupId>
     <artifactId>quickshop-hikari</artifactId>
-    <version>5.1.0.1</version>
+    <version>5.1.1.0</version>
     <packaging>pom</packaging>
     <name>quickshop-hikari</name>
     <description>Another QuickShop fork</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu</groupId>
     <artifactId>quickshop-hikari</artifactId>
-    <version>5.1.0.0</version>
+    <version>5.1.0.1</version>
     <packaging>pom</packaging>
     <name>quickshop-hikari</name>
     <description>Another QuickShop fork</description>

--- a/quickshop-api/pom.xml
+++ b/quickshop-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-api/pom.xml
+++ b/quickshop-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/ShopManager.java
+++ b/quickshop-api/src/main/java/com/ghostchu/quickshop/api/shop/ShopManager.java
@@ -336,7 +336,7 @@ public interface ShopManager {
      * @param info The info object
      * @return True if the shop was register successfully.
      */
-    void registerShop(@NotNull Shop shop, boolean persist);
+    CompletableFuture<?> registerShop(@NotNull Shop shop, boolean persist);
 
     /**
      * Unregister a shop from database.
@@ -344,7 +344,7 @@ public interface ShopManager {
      * @param info The info object
      * @return True if the shop was unregister successfully.
      */
-    void unregisterShop(@NotNull Shop shop, boolean persist);
+    CompletableFuture<?> unregisterShop(@NotNull Shop shop, boolean persist);
 
     /**
      * Send a purchaseSuccess message for a player.

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
     </parent>
 
     <artifactId>quickshop-bukkit</artifactId>

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
     </parent>
 
     <artifactId>quickshop-bukkit</artifactId>

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/SimpleTextManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/SimpleTextManager.java
@@ -788,7 +788,7 @@ public class SimpleTextManager implements TextManager, Reloadable, SubPasteItem 
         @Override
         public void send() {
             if (sender == null) {
-                throw new IllegalStateException("Sender is null");
+                return;
             }
             for (Component s : forLocale()) {
                 MsgUtil.sendDirectMessage(sender, s);
@@ -935,7 +935,7 @@ public class SimpleTextManager implements TextManager, Reloadable, SubPasteItem 
         @Override
         public void send() {
             if (sender == null) {
-                throw new IllegalStateException("Sender is null");
+                return;
             }
             Component lang = forLocale();
             MsgUtil.sendDirectMessage(sender, lang);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -1243,7 +1243,7 @@ public class ContainerShop implements Shop, Reloadable {
                 new BlockPos(getLocation()), this.owner, this.price,
                 Util.serialize(this.originalItem), isUnlimited() ? 1 : 0
                 , getShopType().toID(),
-                saveExtraToYaml(), this.currency,this.disableDisplay,
+                saveExtraToYaml(), this.currency, this.disableDisplay,
                 this.taxAccount, inventoryWrapperProvider,
                 saveToSymbolLink(), this.playerGroup);
     }
@@ -1561,6 +1561,7 @@ public class ContainerShop implements Shop, Reloadable {
                 ")" +
                 " Owner: " + LegacyComponentSerializer.legacySection().serialize(this.ownerName(false, MsgUtil.getDefaultGameLanguageLocale())) + " - " + getOwner() +
                 ", Unlimited: " + isUnlimited() +
-                " Price: " + getPrice();
+                ", Item: " + LegacyComponentSerializer.legacySection().serialize(Util.getItemStackName(getItem())) +
+                ", Price: " + getPrice();
     }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimplePriceLimiter.java
@@ -105,6 +105,13 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
             configuration.set("version", 2);
             anyChanges = true;
         }
+        if (configuration.getInt("version") == 2) {
+            if (configuration.getDouble("undefined.max") == -1) {
+                configuration.set("undefined.min", 999999999999999999999999999999.99); // DECIMAL (32,2) MAX
+            }
+            configuration.set("version", 3);
+            anyChanges = true;
+        }
         return anyChanges;
     }
 
@@ -137,6 +144,7 @@ public class SimplePriceLimiter implements Reloadable, PriceLimiter, SubPasteIte
         }
         return new RuleSet(items, bypassPermission, currency, min, max);
     }
+
     /**
      * Check the price restriction rules
      *

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ProgressMonitor.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ProgressMonitor.java
@@ -1,0 +1,44 @@
+package com.ghostchu.quickshop.util;
+
+import org.apache.commons.lang3.tuple.Triple;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+public class ProgressMonitor<T> implements Iterable<T>{
+    private final Collection<T> elements;
+    private final Consumer<Triple<Long, Long,T>> callback;
+
+    public ProgressMonitor(@NotNull Collection<T> elements, Consumer<Triple<Long, Long, T>> callback){
+        this.elements = elements;
+        this.callback = callback;
+    }
+    public ProgressMonitor(@NotNull T[] elements, Consumer<Triple<Long, Long, T>> callback){
+        this.elements = Arrays.asList(elements);
+        this.callback = callback;
+    }
+    @NotNull
+    @Override
+    public Iterator<T> iterator() {
+        Iterator<T> parent = elements.iterator();
+        long total = elements.size();
+        AtomicLong count = new AtomicLong(0L);
+        return new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                return parent.hasNext();
+            }
+
+            @Override
+            public T next() {
+                T dat = parent.next();
+                callback.accept(Triple.of(count.incrementAndGet(), total, dat));
+                return dat;
+            }
+        };
+    }
+}

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/config/ConfigUpdateScript.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/config/ConfigUpdateScript.java
@@ -106,6 +106,8 @@ public class ConfigUpdateScript {
 
     @UpdateScript(version = 1022)
     public void privacySystem() {
+        getConfig().set("shop.use-cache", true);
+        getConfig().set("use-caching", null);
         getConfig().set("disabled-metrics", null);
         getConfig().set("privacy.type.STATISTIC", true);
         getConfig().set("privacy.type.RESEARCH", true);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/config/ConfigUpdateScript.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/config/ConfigUpdateScript.java
@@ -104,7 +104,7 @@ public class ConfigUpdateScript {
         getConfig().set("use-caching", null);
     }
 
-    @UpdateScript(version = 1021)
+    @UpdateScript(version = 1022)
     public void privacySystem() {
         getConfig().set("disabled-metrics", null);
         getConfig().set("privacy.type.STATISTIC", true);

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -1641,6 +1641,25 @@ addon:
       internal error, please contact server administrator.
     command:
       displaycontrol: <yellow>Toggle your QuickShop display showcasing
+  reremake-migrator:
+    commands:
+      migratefromreremake: Migrate QuickShop-Reremake's data to QuickShop-Hikari
+    server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
+    starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
+    executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+    completed: "<aqua>Migrate completed, please shutdown your server and remove QuickShop-Reremake from plugins directory."
+    modules:
+      config:
+        copy-values: "<yellow>Copying values (total {0} entries)..."
+        copying-value: "<gray> - Copying <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        migrate-price-restriction: "<yellow>Migrating price-restriction related settings..."
+        migrate-price-restriction-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+      shop:
+        start-migrate: "<yellow>Migrating shops (total {0} entries)..."
+        migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
+        register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        saving-shops: "<yellow>Saving shops..."
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -1662,6 +1662,7 @@ addon:
         migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
         unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
         register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
+        save-entry: "<gray> - Saving shop <dark_gray>({0}/{1})</dark_gray>..."
         saving-shops: "<yellow>Saving <gold>{0}</gold> shops, this may need a while™ (the time based on shops amounts)..."
         conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -1662,7 +1662,7 @@ addon:
         migrate-entry: "<gray> - Migrating <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
         unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
         register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
-        saving-shops: "<yellow>Saving shops..."
+        saving-shops: "<yellow>Saving <gold>{0}</gold> shops, this may need a while™ (the time based on shops amounts)..."
         conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -1647,9 +1647,10 @@ addon:
     server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
     starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
     executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
-    completed: "<aqua>Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    completed: "<green>Done! Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
     join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
     join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
+    failed: "<red>Migration progress exited with error, please check the server console."
     modules:
       config:
         copy-values: "<yellow>Copying values (total {0} entries)..."

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -1663,6 +1663,7 @@ addon:
         unloading-reremake: "<gold>Unloading Reremake to avoid data overwrite..."
         register-entry: "<gray> - Registering <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
         saving-shops: "<yellow>Saving shops..."
+        conflict: "<gray> - CONFLICT > Detects a conflict between a Reremake store and an existing Hikari store location, taking a predefined behavior: <dark_gray>{0}</dark_gray>"
 compat:
   advancedchests:
     created: <green>You're successfully created a shop on AdvancedChests container!

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -1647,7 +1647,9 @@ addon:
     server-not-empty: "<red>No players are allowed to be online on the server during the conversion progress, please enable server whitelist or maintenance mode."
     starting-convert-progress: "<gold>Starting the convert progress, <red>DO NOT SHUTDOWN YOUR SERVER!</red>"
     executing: "<gold>Executing migrate component <aqua>{0}</aqua> <dark_gray>({1}/{2})</dark_gray>..."
-    completed: "<aqua>Migrate completed, please shutdown your server and remove QuickShop-Reremake from plugins directory."
+    completed: "<aqua>Migrate completed, please restart your server and remove QuickShop-Reremake from plugins directory."
+    join_blocking_converting: "<red>[QuickShop-Hikari Migrator] This server is performing a data conversion and you cannot join the server at this time, try again later!"
+    join_blocking_finished: "<red>[QuickShop-Hikari Migrator] This server has just completed a data conversion and is waiting for a reboot to apply the changes, try again later!"
     modules:
       config:
         copy-values: "<yellow>Copying values (total {0} entries)..."

--- a/quickshop-bukkit/src/main/resources/price-restriction.yml
+++ b/quickshop-bukkit/src/main/resources/price-restriction.yml
@@ -1,4 +1,4 @@
-version: 1
+version: 3
 whole-number-only: false  # This option not control by enable option, always enabled
 undefined: # This option not control by enable option, always enabled
   min: 0.01 # Can be zero if you want player create a free shop

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.1.0.0</version>
+        <version>5.1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.1.0.1</version>
+        <version>5.1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a new module `reremake-migrator` for migrating data from QuickShop-Reremake to QuickShop-Hikari.
- New Feature: Introduced asynchronous operations in `registerShop` and `unregisterShop` methods in `SimpleShopManager`.
- Refactor: Updated the `quickshop-hikari` artifact version from `5.1.0.0` to `5.1.1.0` across multiple modules.
- Refactor: Improved null handling in `SimpleTextManager`'s `send()` method.
- Bug Fix: Fixed configuration migration issues in `ConfigMigrate` class of `reremake-migrator` module.
- Bug Fix: Updated configuration version handling in `SimplePriceLimiter`'s `performMigrate` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->