### PR TITLE
5.2.0.0

### DIFF
--- a/addon/bluemap/pom.xml
+++ b/addon/bluemap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discordsrv/pom.xml
+++ b/addon/discordsrv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discount/pom.xml
+++ b/addon/discount/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/displaycontrol/pom.xml
+++ b/addon/displaycontrol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/dynmap/pom.xml
+++ b/addon/dynmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/limited/pom.xml
+++ b/addon/limited/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/list/pom.xml
+++ b/addon/list/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/plan/pom.xml
+++ b/addon/plan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/reremake-migrator/pom.xml
+++ b/addon/reremake-migrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -14,10 +14,10 @@ import com.google.common.io.Files;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.Container;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.InventoryHolder;
 import org.maxgamer.quickshop.api.shop.Shop;
 
 import java.io.File;
@@ -63,7 +63,7 @@ public class ShopMigrate extends AbstractMigrateComponent {
                     }
                 }
                 BlockState block = shopLoc.getBlock().getState();
-                if (!(block instanceof Container container)) {
+                if (!(block instanceof InventoryHolder container)) {
                     getHikari().logger().warn("Shop Invalid: Shop block not a valid Container, failed to create InventoryHolder.");
                     return;
                 }

--- a/addon/shopitemonly/pom.xml
+++ b/addon/shopitemonly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/compatibility/advancedregionmarket/pom.xml
+++ b/compatibility/advancedregionmarket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/angelchest/pom.xml
+++ b/compatibility/angelchest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bentobox/pom.xml
+++ b/compatibility/bentobox/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord-geyser/pom.xml
+++ b/compatibility/bungeecord-geyser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord/pom.xml
+++ b/compatibility/bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/chestprotect/pom.xml
+++ b/compatibility/chestprotect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/clearlag/pom.xml
+++ b/compatibility/clearlag/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/elitemobs/pom.xml
+++ b/compatibility/elitemobs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/griefprevention/pom.xml
+++ b/compatibility/griefprevention/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/openinv/pom.xml
+++ b/compatibility/openinv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/plotsquared/pom.xml
+++ b/compatibility/plotsquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/residence/pom.xml
+++ b/compatibility/residence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/superiorskyblock/pom.xml
+++ b/compatibility/superiorskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldedit/pom.xml
+++ b/compatibility/worldedit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldguard/pom.xml
+++ b/compatibility/worldguard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/platform/quickshop-platform-interface/pom.xml
+++ b/platform/quickshop-platform-interface/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-abstract/pom.xml
+++ b/platform/quickshop-platform-spigot-abstract/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu</groupId>
     <artifactId>quickshop-hikari</artifactId>
-    <version>5.1.2.1</version>
+    <version>5.2.0.0</version>
     <packaging>pom</packaging>
     <name>quickshop-hikari</name>
     <description>Another QuickShop fork</description>

--- a/quickshop-api/pom.xml
+++ b/quickshop-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
     </parent>
 
     <artifactId>quickshop-bukkit</artifactId>

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/NbtApiInitializer.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/NbtApiInitializer.java
@@ -1,12 +1,9 @@
 package com.ghostchu.quickshop;
 
-import com.ghostchu.quickshop.common.util.CommonUtil;
 import com.ghostchu.quickshop.common.util.JsonUtil;
-import com.ghostchu.quickshop.platform.spigot.AbstractSpigotPlatform;
 import com.google.common.hash.Hashing;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
 import lombok.Data;
@@ -38,7 +35,7 @@ public class NbtApiInitializer {
     }
 
     private boolean checkNeedDownloadNbtApi() {
-        return Bukkit.getPluginManager().getPlugin("NBT-API") == null;
+        return Bukkit.getPluginManager().getPlugin("NBTAPI") == null;
     }
 
     private void init(Logger logger) throws IOException, InvalidPluginException, InvalidDescriptionException {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentPreview.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentPreview.java
@@ -4,8 +4,8 @@ import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.api.command.CommandParser;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermission;
-import com.ghostchu.quickshop.shop.ContainerShop;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
 
@@ -17,7 +17,7 @@ public class SubCommand_SilentPreview extends SubCommand_SilentBase {
 
     @Override
     protected void doSilentCommand(Player sender, @NotNull Shop shop, @NotNull CommandParser parser) {
-        if (!(shop instanceof ContainerShop)) {
+        if (!(shop instanceof InventoryHolder holder)) {
             // This should never happen
             plugin.text().of(sender, "not-looking-at-shop").send();
             return;

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/DataTables.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/DataTables.java
@@ -55,7 +55,7 @@ public enum DataTables {
 
     SHOP_MAP("shop_map", (table) -> {
         // BLOCK LOCATION DATA
-        table.addColumn("world", "VARCHAR(32) NOT NULL");
+        table.addColumn("world", "VARCHAR(255) NOT NULL");
         table.addColumn("x", "INT NOT NULL");
         table.addColumn("y", "INT NOT NULL");
         table.addColumn("z", "INT NOT NULL");

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
@@ -171,8 +171,12 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
     }
 
     private void fastBackup() {
-        DatabaseIOUtil databaseIOUtil = new DatabaseIOUtil(this);
-        databaseIOUtil.performBackup("database-upgrade");
+        try {
+            DatabaseIOUtil databaseIOUtil = new DatabaseIOUtil(this);
+            databaseIOUtil.performBackup("database-upgrade");
+        }catch (Throwable throwable){
+            plugin.logger().warn("Failed to backup the database.",throwable);
+        }
     }
 
     private void upgradeBenefit() {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
@@ -105,7 +105,7 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
                 .build().execute()) {
             ResultSet result = query.getResultSet();
             if (!result.next()) {
-                return LATEST_DATABASE_VERSION; // Default latest version
+                return -1; // Default latest version
             }
             return Integer.parseInt(result.getString("value"));
         } catch (SQLException e) {
@@ -811,6 +811,9 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
 
         public void upgrade() throws Exception {
             int currentDatabaseVersion = parent.getDatabaseVersion();
+            if(currentDatabaseVersion == -1){
+                currentDatabaseVersion = 11;
+            }
             if (currentDatabaseVersion > parent.LATEST_DATABASE_VERSION) {
                 throw new IllegalStateException("The database version is newer than this build supported.");
             }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/database/SimpleDatabaseHelperV2.java
@@ -55,7 +55,7 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
     @NotNull
     private final String prefix;
 
-    private final int LATEST_DATABASE_VERSION = 13;
+    private final int LATEST_DATABASE_VERSION = 14;
 
     public SimpleDatabaseHelperV2(@NotNull QuickShop plugin, @NotNull SQLManager manager, @NotNull String prefix) throws Exception {
         this.plugin = plugin;
@@ -225,6 +225,13 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
                 manager.alterTable(DataTables.LOG_TRANSACTION.getName())
                         .modifyColumn("tax_account", "VARCHAR(64)")
                         .executeFuture()).join();
+    }
+
+    private void upgradeWorldNameLength(){
+        fastBackup();
+        manager.alterTable(DataTables.SHOP_MAP.getName())
+                .modifyColumn("world", "VARCHAR(255) NOT NULL")
+                .executeFuture().join();
     }
 
     private void upgradeTablesEncoding() {
@@ -869,6 +876,11 @@ public class SimpleDatabaseHelperV2 implements DatabaseHelper {
                 logger.info("Data upgrading: Converting data tables to utf8mb4...");
                 parent.upgradeTablesEncoding();
                 currentDatabaseVersion = 13;
+            }
+            if (currentDatabaseVersion == 13) {
+                logger.info("Data upgrading: Converting shop_map world length to 255...");
+                parent.upgradeWorldNameLength();
+                currentDatabaseVersion = 14;
             }
             parent.setDatabaseVersion(currentDatabaseVersion).join();
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -1577,7 +1577,7 @@ public class SimpleShopManager implements ShopManager, Reloadable {
                 } else {
                     // optimize for performance
                     BlockState state = PaperLib.getBlockState(currentBlock, false).getState();
-                    if (!(state instanceof Container)) {
+                    if (!(state instanceof InventoryHolder holder)) {
                         return null;
                     }
                     @Nullable final Block half = Util.getSecondHalf(currentBlock);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/inventory/BukkitInventoryWrapper.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/inventory/BukkitInventoryWrapper.java
@@ -6,8 +6,6 @@ import com.ghostchu.quickshop.api.inventory.InventoryWrapperIterator;
 import com.ghostchu.quickshop.api.inventory.InventoryWrapperManager;
 import com.ghostchu.quickshop.api.inventory.InventoryWrapperType;
 import org.bukkit.Location;
-import org.bukkit.block.Container;
-import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -72,9 +70,9 @@ public class BukkitInventoryWrapper implements InventoryWrapper {
 
     @Override
     public boolean isValid() {
-        if (this.inventory instanceof BlockInventoryHolder) {
+        if (this.inventory instanceof InventoryHolder) {
             if (this.inventory.getLocation() != null) {
-                return this.inventory.getLocation().getBlock() instanceof Container;
+                return this.inventory.getLocation().getBlock() instanceof InventoryHolder;
             }
             return false;
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/inventory/BukkitInventoryWrapperManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/inventory/BukkitInventoryWrapperManager.java
@@ -14,7 +14,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.Container;
 import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,10 +39,10 @@ public class BukkitInventoryWrapperManager implements InventoryWrapperManager {
             throw new IllegalArgumentException("Invalid symbol link: Invalid world name.");
         }
         BlockState block = PaperLib.getBlockState(world.getBlockAt(blockPos.getX(), blockPos.getY(), blockPos.getZ()), false).getState();
-        if (!(block instanceof Container container)) {
-            throw new IllegalArgumentException("Invalid symbol link: Target block not a Container (map changed/resetted?)");
+        if (!(block instanceof InventoryHolder holder)) {
+            throw new IllegalArgumentException("Invalid symbol link: Target block not a InventoryHolder (map changed/resetted?)");
         }
-        return new BukkitInventoryWrapper(container.getInventory());
+        return new BukkitInventoryWrapper(holder.getInventory());
     }
 
     @Deprecated

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -123,10 +123,16 @@ public class Util {
         }
         // Specified types by configuration
         if (!isShoppables(b.getType())) {
+            Log.debug(b.getType().name() + " not a shoppable");
             return false;
         }
         final BlockState bs = PaperLib.getBlockState(b, false).getState();
-        return bs instanceof InventoryHolder;
+        boolean container =  bs instanceof InventoryHolder;
+        if(!container){
+            Log.debug(b.getType().name() + " not a container");
+            return false;
+        }
+        return true;
     }
 
     public static boolean isBlacklistWorld(@NotNull World world) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/config/ConfigUpdateScript.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/config/ConfigUpdateScript.java
@@ -114,6 +114,13 @@ public class ConfigUpdateScript {
         getConfig().set("privacy.type.DIAGNOSTIC", true);
     }
 
+    @UpdateScript(version = 1023)
+    public void allowPublicKeyRetrieve() {
+        if(!getConfig().isSet("database.properties.allowPublicKeyRetrieval")){
+            getConfig().set("database.properties.allowPublicKeyRetrieval", true);
+        }
+    }
+
 
 
     @UpdateScript(version = 1004)

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -124,7 +124,7 @@ public final class EnvironmentChecker {
     }
     @EnvCheckEntry(name = "ModdedServer Database Driver Test", priority = 5)
     public ResultContainer moddedServerDatabaseDriverTest() {
-        boolean trigged = isForgeBasedServer() || isFabricBasedServer();
+        boolean trigged = isForgeBasedServer() || isFabricBasedServer() && plugin.getConfig().getBoolean("database.mysql",false);
         if (trigged) {
             return new ResultContainer(CheckResult.STOP_WORKING, "You can't use H2 database driver on Forge/Fabric hybird server (it's buggy and will destroy your data). Use a MySQL server instead.");
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -124,7 +124,7 @@ public final class EnvironmentChecker {
     }
     @EnvCheckEntry(name = "ModdedServer Database Driver Test", priority = 5)
     public ResultContainer moddedServerDatabaseDriverTest() {
-        boolean trigged = isForgeBasedServer() || isFabricBasedServer() && plugin.getConfig().getBoolean("database.mysql",false);
+        boolean trigged = (isForgeBasedServer() || isFabricBasedServer()) && plugin.getConfig().getBoolean("database.mysql",false);
         if (trigged) {
             return new ResultContainer(CheckResult.STOP_WORKING, "You can't use H2 database driver on Forge/Fabric hybird server (it's buggy and will destroy your data). Use a MySQL server instead.");
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -128,7 +128,7 @@ public final class EnvironmentChecker {
         if (trigged) {
             return new ResultContainer(CheckResult.STOP_WORKING, "You can't use H2 database driver on Forge/Fabric hybird server (it's buggy and will destroy your data). Use a MySQL server instead.");
         }
-        return new ResultContainer(CheckResult.PASSED, "Server is unmodified.");
+        return new ResultContainer(CheckResult.PASSED, "OK");
     }
 
     public boolean isForgeBasedServer() {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -122,6 +122,14 @@ public final class EnvironmentChecker {
         }
         return new ResultContainer(CheckResult.PASSED, "Server is unmodified.");
     }
+    @EnvCheckEntry(name = "ModdedServer Database Driver Test", priority = 5)
+    public ResultContainer moddedServerDatabaseDriverTest() {
+        boolean trigged = isForgeBasedServer() || isFabricBasedServer();
+        if (trigged) {
+            return new ResultContainer(CheckResult.STOP_WORKING, "You can't use H2 database driver on Forge/Fabric hybird server (it's buggy and will destroy your data). Use a MySQL server instead.");
+        }
+        return new ResultContainer(CheckResult.PASSED, "Server is unmodified.");
+    }
 
     public boolean isForgeBasedServer() {
         //Forge server detect - Arclight

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -124,7 +124,7 @@ public final class EnvironmentChecker {
     }
     @EnvCheckEntry(name = "ModdedServer Database Driver Test", priority = 5)
     public ResultContainer moddedServerDatabaseDriverTest() {
-        boolean trigged = (isForgeBasedServer() || isFabricBasedServer()) && plugin.getConfig().getBoolean("database.mysql",false);
+        boolean trigged = (isForgeBasedServer() || isFabricBasedServer()) && !plugin.getConfig().getBoolean("database.mysql",false);
         if (trigged) {
             return new ResultContainer(CheckResult.STOP_WORKING, "You can't use H2 database driver on Forge/Fabric hybird server (it's buggy and will destroy your data). Use a MySQL server instead.");
         }

--- a/quickshop-bukkit/src/main/resources/config.yml
+++ b/quickshop-bukkit/src/main/resources/config.yml
@@ -1,7 +1,7 @@
 # QuickShop-Hikari Plugin Configuration
 
 #Do not touch this if you don't know what you're doing!
-config-version: 1022
+config-version: 1023
 
 #Set the default language code the plugin should use
 #Set it to default will use your system language.
@@ -152,6 +152,7 @@ database:
     prepStmtCacheSqlLimit: 2048
     useUnicode: true
     characterEncoding: utf8
+    allowPublicKeyRetrieval: true
 
 #Limits the amount of shops a player can create and own.
 limits:

--- a/quickshop-bukkit/src/main/resources/plugin.yml
+++ b/quickshop-bukkit/src/main/resources/plugin.yml
@@ -11,6 +11,8 @@ softdepend:
   - CMI
   - ProtocolLib
   - NBTAPI
+  - NBT-API
+  - ItemNBTAPI
 api-version: 1.18
 # TODO: https://github.com/PaperMC/Paper/pull/7177
 libraries:

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.1.2.1</version>
+        <version>5.2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the `quickshop-hikari` artifact version from `5.1.2.1` to `5.2.0.0` across multiple projects, ensuring compatibility with the latest dependencies.
- Refactor: In the `reremake-migrator` addon, refactored the `migrate()` method to use `InventoryHolder` instead of `Container`, improving code consistency and compatibility with newer API versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->