### PR TITLE
shade slf4j into jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,14 @@
                                         <include>de.tr7zw:item-nbt-api:*</include>
                                         <include>io.papermc:paperlib:*</include>
                                         <include>org.bstats:*</include>
+                                        <include>org.slf4j:*:*</include>
                                     </includes>
                                 </artifactSet>
                                 <relocations>
+                                    <relocation>
+                                        <pattern>org.slf4j.</pattern>
+                                        <shadedPattern>com.ghostchu.quickshop.shade.org.slf4j.</shadedPattern>
+                                    </relocation>
                                     <relocation>
                                         <pattern>io.papermc.lib.</pattern>
                                         <shadedPattern>com.ghostchu.quickshop.shade.io.papermc.lib.</shadedPattern>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated Maven configuration to resolve potential conflicts with `org.slf4j` library. The project now includes a new `<include>` entry for the `org.slf4j` dependency and a relocation rule that maps the `org.slf4j` package to the shaded package `com.ghostchu.quickshop.shade.org.slf4j`. This change enhances the stability of the project by preventing version mismatches or conflicts with the `org.slf4j` library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->