### PR TITLE
5.2.0.5

### DIFF
--- a/addon/bluemap/pom.xml
+++ b/addon/bluemap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discordsrv/pom.xml
+++ b/addon/discordsrv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discount/pom.xml
+++ b/addon/discount/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/displaycontrol/pom.xml
+++ b/addon/displaycontrol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/dynmap/pom.xml
+++ b/addon/dynmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/limited/pom.xml
+++ b/addon/limited/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/list/pom.xml
+++ b/addon/list/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/plan/pom.xml
+++ b/addon/plan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/reremake-migrator/pom.xml
+++ b/addon/reremake-migrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ConfigMigrate.java
@@ -48,6 +48,7 @@ public class ConfigMigrate extends AbstractMigrateComponent {
         migrateCommandAlias();
         migratePriceRestrictions();
         setFixedConfigValues();
+        getHikariJavaPlugin().reloadConfig();
         return true;
     }
 

--- a/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
+++ b/addon/reremake-migrator/src/main/java/com/ghostchu/quickshop/addon/reremakemigrator/migratecomponent/ShopMigrate.java
@@ -70,7 +70,7 @@ public class ShopMigrate extends AbstractMigrateComponent {
                         -1,
                         shopLoc,
                         Math.min(reremakeShop.getPrice(), 999999999999999999999999999999.99), // DECIMAL (32,2) MAX
-                        reremakeShop.getItem(),
+                        reremakeShop.getItem().clone(),
                         QUserImpl.createSync(getHikari().getPlayerFinder(), reremakeShop.getOwner()),
                         reremakeShop.isUnlimited(),
                         ShopType.fromID(reremakeShop.getShopType().toID()),

--- a/addon/shopitemonly/pom.xml
+++ b/addon/shopitemonly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/compatibility/advancedregionmarket/pom.xml
+++ b/compatibility/advancedregionmarket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/angelchest/pom.xml
+++ b/compatibility/angelchest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bentobox/pom.xml
+++ b/compatibility/bentobox/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord-geyser/pom.xml
+++ b/compatibility/bungeecord-geyser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord/pom.xml
+++ b/compatibility/bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/chestprotect/pom.xml
+++ b/compatibility/chestprotect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/clearlag/pom.xml
+++ b/compatibility/clearlag/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/elitemobs/pom.xml
+++ b/compatibility/elitemobs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/griefprevention/pom.xml
+++ b/compatibility/griefprevention/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/openinv/pom.xml
+++ b/compatibility/openinv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/plotsquared/pom.xml
+++ b/compatibility/plotsquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/residence/pom.xml
+++ b/compatibility/residence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/superiorskyblock/pom.xml
+++ b/compatibility/superiorskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldedit/pom.xml
+++ b/compatibility/worldedit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldguard/pom.xml
+++ b/compatibility/worldguard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/platform/quickshop-platform-interface/pom.xml
+++ b/platform/quickshop-platform-interface/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-abstract/pom.xml
+++ b/platform/quickshop-platform-spigot-abstract/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu</groupId>
     <artifactId>quickshop-hikari</artifactId>
-    <version>5.2.0.4</version>
+    <version>5.2.0.5</version>
     <packaging>pom</packaging>
     <name>quickshop-hikari</name>
     <description>Another QuickShop fork</description>

--- a/quickshop-api/pom.xml
+++ b/quickshop-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
     </parent>
 
     <artifactId>quickshop-bukkit</artifactId>

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
@@ -5,8 +5,11 @@ import com.ghostchu.quickshop.api.command.CommandHandler;
 import com.ghostchu.quickshop.api.command.CommandParser;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.common.util.QuickExecutor;
+import com.ghostchu.quickshop.shop.SimpleShopManager;
+import com.ghostchu.quickshop.shop.cache.SimpleShopCache;
 import com.ghostchu.quickshop.util.MsgUtil;
 import com.ghostchu.quickshop.util.performance.BatchBukkitExecutor;
+import com.google.common.cache.Cache;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -55,8 +58,16 @@ public class SubCommand_Debug implements CommandHandler<CommandSender> {
             case "check-shop-debug" -> handleShopInfo(sender, subParams);
             case "set-property" -> handleProperty(sender, subParams);
             case "await-profile-io-tasks" -> handleProfileIOTasksInfo(sender, subParams);
+            case "reset-shop-caches" -> handleShopCacheResetting(sender, subParams);
             default -> plugin.text().of(sender, "debug.arguments-invalid", parser.getArgs().get(0)).send();
         }
+    }
+
+    private void handleShopCacheResetting(CommandSender sender, List<String> subParams) {
+        SimpleShopManager shopManager = (SimpleShopManager) plugin.getShopManager();
+        SimpleShopCache simpleShopCache = (SimpleShopCache) shopManager.getShopCache();
+        simpleShopCache.getCaches().values().forEach(Cache::invalidateAll);
+        sender.sendMessage("Cleared!");
     }
 
     private void handleProfileIOTasksInfo(CommandSender sender, List<String> subParams) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/economy/Economy_Vault.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/economy/Economy_Vault.java
@@ -112,6 +112,7 @@ public class Economy_Vault extends AbstractEconomy implements Listener {
             if (plugin.getSentryErrorReporter() != null) {
                 plugin.getSentryErrorReporter().ignoreThrow();
             }
+            plugin.logger().warn("Failure - deposit - " + name + " - " + amount + " - " + world + " - " + currency);
             plugin.logger().warn(String.format(ERROR_MESSAGE, getProviderName()), t);
             return false;
         }
@@ -147,6 +148,7 @@ public class Economy_Vault extends AbstractEconomy implements Listener {
                 plugin.logger().warn("Deposit failed and player name is NULL, Player uuid: " + trader.getUniqueId() + ". Provider (" + getProviderName() + ")");
                 return false;
             }
+            plugin.logger().warn("Failure - deposit - " + trader + " - " + amount + " - " + world + " - " + currency);
             plugin.logger().warn(String.format(ERROR_MESSAGE, getProviderName()), t);
             return false;
         }
@@ -180,6 +182,7 @@ public class Economy_Vault extends AbstractEconomy implements Listener {
             if (plugin.getSentryErrorReporter() != null) {
                 plugin.getSentryErrorReporter().ignoreThrow();
             }
+            plugin.logger().warn("Failure - getBalance - " + name + " - " + world + " - " + currency);
             plugin.logger().warn(String.format(ERROR_MESSAGE, getProviderName()), t);
             return 0.0;
         }
@@ -212,6 +215,7 @@ public class Economy_Vault extends AbstractEconomy implements Listener {
             if (plugin.getSentryErrorReporter() != null) {
                 plugin.getSentryErrorReporter().ignoreThrow();
             }
+            plugin.logger().warn("Failure - getBalance - " + player + " - " + world + " - " + currency);
             plugin.logger().warn(String.format(ERROR_MESSAGE, getProviderName()), t);
             return 0.0;
         }
@@ -273,6 +277,7 @@ public class Economy_Vault extends AbstractEconomy implements Listener {
             if (plugin.getSentryErrorReporter() != null) {
                 plugin.getSentryErrorReporter().ignoreThrow();
             }
+            plugin.logger().warn("Failure - withdraw - " + name + " - " + amount + " - " + world + " - " + currency);
             plugin.logger().warn(String.format(ERROR_MESSAGE, getProviderName()), t);
             return false;
         }
@@ -310,6 +315,7 @@ public class Economy_Vault extends AbstractEconomy implements Listener {
                 plugin.logger().warn("Withdraw failed and player name is NULL, Player uuid: {}", trader.getUniqueId() + ", Provider: " + getProviderName());
                 return false;
             }
+            plugin.logger().warn("Failure - withdraw - " + trader + " - " + amount + " - " + world + " - " + currency);
             plugin.logger().warn(String.format(ERROR_MESSAGE, getProviderName()), t);
             return false;
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
@@ -104,7 +104,7 @@ public class ShopLoader implements SubPasteItem {
                 plugin.logger().error("Failed to load shop {}.", shop.getShopId(), e);
             }
         }));
-        plugin.logger().info("Used {}ms to load {} shops into memory ({} shops will be loaded after chunks loaded).", shopTotalTimer.stopAndGetTimePassed(), successCounter.get(), chunkNotLoaded.get());
+        plugin.logger().info("Used {}ms to load {} shops into memory ({} shops will be loaded after chunks/world loaded).", shopTotalTimer.stopAndGetTimePassed(), successCounter.get(), chunkNotLoaded.get());
     }
 
     private CompletableFuture<Void> loadShopFromShopRecord(String worldName, ShopRecord shopRecord, boolean deleteCorruptShops, List<Shop> shopsLoadInNextTick, AtomicInteger successCounter, AtomicInteger chunkNotLoaded) {
@@ -138,6 +138,9 @@ public class ShopLoader implements SubPasteItem {
             if (!worldName.equals(infoRecord.getWorld())) {
                 return ShopLoadResult.WORLD_NOT_MATCH_SKIPPED;
             }
+        }
+        if (Bukkit.getWorld(infoRecord.getWorld()) == null) {
+            return ShopLoadResult.LOAD_AFTER_CHUNK_LOADED;
         }
         // Shop basic check
         if (dataRecord.getInventoryWrapper() == null) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -935,7 +935,7 @@ public class SimpleShopManager implements ShopManager, Reloadable {
             return null;
         }
         if (!this.useShopCache) {
-            return getShopIncludeAttachedViaCache(loc);
+            return getShopIncludeAttached(loc);
         }
         return shopCache.get(ShopCacheNamespacedKey.INCLUDE_ATTACHED, loc, true);
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -163,6 +163,10 @@ public class SimpleShopManager implements ShopManager, Reloadable {
         this.shopCache = new SimpleShopCache(plugin, map);
     }
 
+    public ShopCache getShopCache() {
+        return shopCache;
+    }
+
     @Override
     public void actionBuying(
             @NotNull Player buyer,

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/cache/SimpleShopCache.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/cache/SimpleShopCache.java
@@ -49,6 +49,10 @@ public class SimpleShopCache implements SubPasteItem, ShopCache {
         }
     }
 
+    public Map<ShopCacheNamespacedKey, Cache<Location, BoxedShop>> getCaches() {
+        return CACHES;
+    }
+
     @Nullable
     @Override
     public Shop get(@NotNull ShopCacheNamespacedKey namespacedKey, @NotNull Location location, boolean allowLoading) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -128,6 +128,9 @@ public class Util {
         final BlockState bs = PaperLib.getBlockState(b, false).getState();
         boolean container = bs instanceof InventoryHolder;
         if (!container) {
+            if (Util.isDevMode()) {
+                Log.debug(b.getType() + " not a container");
+            }
             return false;
         }
         return true;

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -123,13 +123,11 @@ public class Util {
         }
         // Specified types by configuration
         if (!isShoppables(b.getType())) {
-            Log.debug(b.getType().name() + " not a shoppable");
             return false;
         }
         final BlockState bs = PaperLib.getBlockState(b, false).getState();
         boolean container = bs instanceof InventoryHolder;
         if (!container) {
-            Log.debug(b.getType().name() + " not a container");
             return false;
         }
         return true;

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -126,8 +126,8 @@ public final class EnvironmentChecker {
     @EnvCheckEntry(name = "ModdedServer Database Driver Test", priority = 5)
     public ResultContainer moddedServerDatabaseDriverTest() {
         boolean trigged = (isForgeBasedServer() || isFabricBasedServer()) && !plugin.getConfig().getBoolean("database.mysql", false);
-        if (trigged) {
-            return new ResultContainer(CheckResult.STOP_WORKING, "You can't use H2 database driver on Forge/Fabric hybird server (it's buggy and will destroy your data). Use a MySQL server instead.");
+        if (trigged && Bukkit.getPluginManager().getPlugin("Mohist") == null) {
+            return new ResultContainer(CheckResult.STOP_WORKING, "You can't use H2 database driver on Forge/Fabric hybird server (it's buggy and will destroy your data on Arclight). Use a MySQL server instead. If you're running Mohist or other no-bug software, add -Dcom.ghostchu.quickshop.util.envcheck.EnvironmentChecker.skip.MODDEDSERVER_DATABASE_DRIVER_TEST=true to startup flag to skip this check.");
         }
         return new ResultContainer(CheckResult.PASSED, "OK");
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/reporter/error/RollbarErrorReporter.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/reporter/error/RollbarErrorReporter.java
@@ -47,7 +47,7 @@ public class RollbarErrorReporter {
 
     public RollbarErrorReporter(@NotNull QuickShop plugin) {
         this.plugin = plugin;
-        Config config = ConfigBuilder.withAccessToken("aeace9eab9e042dfb43d97d39728e19c")
+        Config config = ConfigBuilder.withAccessToken("feae3ac28ad84326b17c1c61e00bd981")
                 .environment(Util.isDevEdition() ? "development" : "production")
                 .platform(Bukkit.getVersion())
                 .codeVersion(QuickShop.getInstance().getVersion())

--- a/quickshop-bukkit/src/main/resources/plugin.yml
+++ b/quickshop-bukkit/src/main/resources/plugin.yml
@@ -13,6 +13,7 @@ softdepend:
   - NBTAPI
   - NBT-API
   - ItemNBTAPI
+  - Mohist
 api-version: 1.18
 # TODO: https://github.com/PaperMC/Paper/pull/7177
 libraries:

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.2.0.4</version>
+        <version>5.2.0.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This is a cumulative update to fix bug reports received since the last LTS release.

## Compatibility

We have partnered with the developers of Mohist and worked on improving the stability of QuickShop-Hikari on Hybird Server.

In the latest Mohist 1.20.1/.2 you can run QuickShop-Hikari perfectly and QuickShop-Hikari protects its store containers from being accessed by other modular pipes or machines.  

Also, in the latest version of Mohist 1.20.1/.2, QuickShop-Hikari is able to use most of the Mod containers as store containers.

## Bug Fixes

1. Fixed annoying NPE error when loading a store that is in an unloaded world during startup, althrough it won't cause any actual issues.
2. [Addon] Fixed an issue where the item stack amount setting was not preserved for stores that migrated from Reremake.

## Changes

1. Disabling the H2 compatibility warning on Mohist will test H2 to work fine on Mohist.
2. Added `/quickshop debug reset-shop-caches` subcommand to allow user purge all caches from memory to debugging the cache issues.

## Privacy

To inform you of warnings about QuickShop-Hikari in accordance with our Privacy Transparency Policy.

We received a [data breach alert from the Rollbar* cloud service](https://rollbar.com/blog/security-notice-2023-09-08/) informing us that our Access Token had been compromised and a forced reset was performed on our affected Token, not only QuickShop-Hikari but also QuickShop-Reremake affected.  
However, our Access Token is distributed with Jar, so whether it was compromised or not doesn't affect us in any way - it's inherently public and we use it for public purposes. As a result, this forced reset caused the Rollbar to no longer be able to report bugs in older versions of QuickShop-Hikari, where we distributed the new Access Token.

We practice our privacy policy and therefore all submitted data is submitted in the minimal sample and anonymized. Your data is therefore not affected. Although no QuickShop-Hikari is actually affected, you can always [disable the error log reporting feature](https://github.com/Ghost-chu/QuickShop-Hikari/blob/bb86508abded5dd637b64622b6d7a19bc86ed6d0/quickshop-bukkit/src/main/resources/config.yml#L610) if you want.

\* Rollbar is a service used by QuickShop-Hikari AND QuickShop-Reremake that used for collecting error logs that generated by QuickShop plugin.


