### PR TITLE
Use StackWalker instead of Throwable to access stack frames

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -283,7 +283,7 @@ public class Util {
      */
     @Deprecated(forRemoval = true)
     public static void debugLog(@NotNull String... logs) {
-        CompletableFuture<Log.Caller> caller = Log.Caller.create();
+        Log.Caller caller = Log.Caller.create();
         for (String log : logs) {
             Log.debug(Level.INFO, log, caller);
         }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/performance/PerfMonitor.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/performance/PerfMonitor.java
@@ -14,7 +14,7 @@ public class PerfMonitor implements AutoCloseable {
     private final Instant startTime;
     @Nullable
     private final Duration exceptedDuration;
-    private final CompletableFuture<Log.Caller> caller;
+    private final Log.Caller caller;
     @Nullable
     private String context;
 


### PR DESCRIPTION
The expensive part of getting stacktrace information comes from the computation done by `fillInStackTrace`, which is called in the constructor of `Throwable`. That means, running the code that comes after async doesn't bring any benefit.

Luckily, since Java 9, we can use the `StackWalker` class to walk stacktraces lazily. By using it, we don't need to discover the full stack trace but only the first few frames, avoiding the heavy cost. As there is no benefit in using `CompletableFuture`, I also removed it and cleaned up the code that is unreachable now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified logging process by removing the use of `CompletableFuture` for creating log instances.
	- Enhanced performance monitoring by streamlining the creation of log instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->