### PR TITLE
5.2.0.9

### DIFF
--- a/addon/bluemap/pom.xml
+++ b/addon/bluemap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discordsrv/pom.xml
+++ b/addon/discordsrv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discount/pom.xml
+++ b/addon/discount/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/displaycontrol/pom.xml
+++ b/addon/displaycontrol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/dynmap/pom.xml
+++ b/addon/dynmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/limited/pom.xml
+++ b/addon/limited/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/list/pom.xml
+++ b/addon/list/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/plan/pom.xml
+++ b/addon/plan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/reremake-migrator/pom.xml
+++ b/addon/reremake-migrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/shopitemonly/pom.xml
+++ b/addon/shopitemonly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/compatibility/advancedregionmarket/pom.xml
+++ b/compatibility/advancedregionmarket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/angelchest/pom.xml
+++ b/compatibility/angelchest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bentobox/pom.xml
+++ b/compatibility/bentobox/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord-geyser/pom.xml
+++ b/compatibility/bungeecord-geyser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord/pom.xml
+++ b/compatibility/bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/chestprotect/pom.xml
+++ b/compatibility/chestprotect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/clearlag/pom.xml
+++ b/compatibility/clearlag/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.12.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>eco</artifactId>
-            <version>6.67.2</version>
+            <version>6.68.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>EcoEnchants</artifactId>
-            <version>11.0.0</version>
+            <version>11.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/compatibility/elitemobs/pom.xml
+++ b/compatibility/elitemobs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/griefprevention/pom.xml
+++ b/compatibility/griefprevention/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.github.angeschossen</groupId>
             <artifactId>LandsAPI</artifactId>
-            <version>6.42.0</version>
+            <version>6.42.15</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/compatibility/openinv/pom.xml
+++ b/compatibility/openinv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/plotsquared/pom.xml
+++ b/compatibility/plotsquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>Reforges</artifactId>
-            <version>6.49.1</version>
+            <version>6.51.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.willfp</groupId>
             <artifactId>eco</artifactId>
-            <version>6.67.2</version>
+            <version>6.68.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/compatibility/residence/pom.xml
+++ b/compatibility/residence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/superiorskyblock/pom.xml
+++ b/compatibility/superiorskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
-            <version>0.100.0.9</version>
+            <version>0.100.0.17</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldedit/pom.xml
+++ b/compatibility/worldedit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldguard/pom.xml
+++ b/compatibility/worldguard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/platform/quickshop-platform-interface/pom.xml
+++ b/platform/quickshop-platform-interface/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-abstract/pom.xml
+++ b/platform/quickshop-platform-spigot-abstract/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_18_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_19_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R2/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R2/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-spigot-v1_20_R3/pom.xml
+++ b/platform/quickshop-platform-spigot-v1_20_R3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.16.1</version>
+                <version>2.16.2</version>
                 <configuration>
                     <generateBackupPoms>true</generateBackupPoms>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu</groupId>
     <artifactId>quickshop-hikari</artifactId>
-    <version>5.2.0.8</version>
+    <version>5.2.0.9</version>
     <packaging>pom</packaging>
     <name>quickshop-hikari</name>
     <description>Another QuickShop fork</description>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.12.1</version>
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>

--- a/quickshop-api/pom.xml
+++ b/quickshop-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
     </parent>
 
     <artifactId>quickshop-bukkit</artifactId>

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>net.tnemc</groupId>
             <artifactId>EconomyCore</artifactId>
-            <version>0.1.2.6-Pre1</version>
+            <version>0.1.2.6-Pre3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -1021,7 +1021,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     @Override
     public ReloadResult reloadModule() throws Exception {
         registerDisplayAutoDespawn();
-        registerOngoingFee();
+        //registerOngoingFee();
         registerUpdater();
         registerShopLock();
         registerDisplayItem();

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>5.2.0.8</version>
+        <version>5.2.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
  - Updated `quickshop-hikari` to version `5.2.0.9`.
  - Upgraded Maven compiler plugin to version `3.12.1`.
  - Updated versions-maven-plugin to version `2.16.2`.
  - Incremented `EcoEnchants` to version `11.2.0`.
  - Updated `eco` to version `6.68.0`.
  - Upgraded `LandsAPI` to version `6.42.15`.
  - Updated `towny` to version `0.100.0.17`.
  - Incremented `EconomyCore` dependency to version `0.1.2.6-Pre3`.

- **Refactor**
  - Modified permission handling logic in `ContainerShop`.
  - Adjusted module reload process in `QuickShop`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->