### PR TITLE
change player bought pt-br translation.yml

### DIFF
--- a/crowdin/lang/pt-BR/messages.yml
+++ b/crowdin/lang/pt-BR/messages.yml
@@ -252,7 +252,7 @@ tableformat:
 quickshop-gui-preview: Pré-visualização de itens do QuickShop GUI
 translate-not-completed-yet-click: A tradução do idioma {0} ainda não foi concluída por {1}. Você quer nos ajudar a melhorar a tradução? Clique aqui!
 taxaccount-invalid: <red>A conta não é inválida, por favor insira um nome de jogador ou uuid(com traços).
-player-bought-from-your-store: <red>{0} comprou {1} {2} da sua loja e você pagou {3} em impostos.
+player-bought-from-your-store: <green>{0} comprou {1} {2} da sua loja, você recebeu {3}.
 reached-maximum-can-create: <red>Você já criou o máximo de lojas! ({0}/{1})
 reached-maximum-create-limit: <red>Você atingiu o número máximo de lojas que você pode criar
 translation-version: 'Versão de suporte: Hikari'


### PR DESCRIPTION
The previous message was misleading the player into believing he was paying taxes to the server instead of receiving money from his store purchase.

Change the message color from red to green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the in-game store purchase confirmation message to include purchase amount and store owner's receipt details, with enhanced color formatting for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->