### PR TITLE
fix: startup & drop papi support

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -311,8 +311,6 @@ public class QuickShop implements QuickShopAPI, Reloadable {
         this.javaPlugin = javaPlugin;
         this.logger = logger;
         this.platform = platform;
-
-        this.menuHandler = new BukkitMenuHandler(javaPlugin, true);
         this.helperMethods = new BukkitHelper();
     }
 
@@ -639,6 +637,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
 
     public final void onEnable() {
         logger.info("QuickShop " + javaPlugin.getFork());
+        this.menuHandler = new BukkitMenuHandler(javaPlugin, true);
         registerService();
         /* Check the running envs is support or not. */
         logger.info("Starting plugin self-test, please wait...");

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/postprocessing/impl/PlaceHolderApiProcessor.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/localization/text/postprocessing/impl/PlaceHolderApiProcessor.java
@@ -15,13 +15,13 @@ import org.jetbrains.annotations.Nullable;
 public class PlaceHolderApiProcessor implements PostProcessor {
     @Override
     public @NotNull Component process(@NotNull Component text, @Nullable CommandSender sender, Component... args) {
-        if (sender instanceof OfflinePlayer offlinePlayer) {
+        /*if (sender instanceof OfflinePlayer offlinePlayer) {
             if (Bukkit.getPluginManager().isPluginEnabled("PlaceHolderAPI")) {
                 String json = GsonComponentSerializer.gson().serialize(text);
                 json = PlaceholderAPI.setPlaceholders(offlinePlayer, json);
                 return GsonComponentSerializer.gson().deserialize(json);
             }
-        }
+        }*/
         return text;
     }
 


### PR DESCRIPTION
Placeholders can be parsed by anyone through item names.