### PR TITLE
SubCommand_Find: Add finding enchantments on books and gear

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
@@ -87,12 +87,11 @@ public class SubCommand_Find implements CommandHandler<Player> {
             //Check distance
             if (distance <= maxDistance) {
                 //Collect valid shop that trading items we want
-                if (!ChatColor.stripColor(LegacyComponentSerializer.legacySection().serialize(Util.getItemStackName(shop.getItem()))).toLowerCase().contains(lookFor)) {
-                    if (!shop.getItem().getType().name().toLowerCase().contains(lookFor)) {
-                        if (plugin.getItemMarker().get(originLookFor) == null) {
-                            continue;
-                        }
-                    }
+                if (!ChatColor.stripColor(LegacyComponentSerializer.legacySection().serialize(Util.getItemStackName(shop.getItem()))).toLowerCase().contains(lookFor)
+                        && !shop.getItem().getType().name().toLowerCase().contains(lookFor)
+                        && !Util.findStringInList(Util.getEnchantsForItemStack(shop.getItem()), lookFor)
+                        && plugin.getItemMarker().get(originLookFor) == null) {
+                    continue;
                 }
                 if (excludeOutOfStock) {
                     if ((shop.isSelling() && shop.getRemainingStock() == 0) || (shop.isBuying() && shop.getRemainingSpace() == 0)) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -529,21 +529,31 @@ public class Util {
         ItemMeta meta = itemStack.getItemMeta();
         if (meta instanceof EnchantmentStorageMeta enchantmentStorageMeta && enchantmentStorageMeta.hasStoredEnchants()) {
             for (Map.Entry<Enchantment, Integer> entry : enchantmentStorageMeta.getStoredEnchants().entrySet()) {
-                Component name;
-                try {
-                    name = plugin.getPlatform().getTranslation(entry.getKey());
-                } catch (Throwable throwable) {
-                    name = MsgUtil.setHandleFailedHover(null, Component.text(entry.getKey().getKey().getKey()));
-                    plugin.logger().warn("Failed to handle translation for Enchantment {}", entry.getKey().getKey(), throwable);
-                }
-                if (entry.getValue() > 1) {
-                    name.append(Component.text(" " + RomanNumber.toRoman(entry.getValue())));
-                }
+                Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
+                enchants.add(name);
+            }
+        } else {
+            for (Map.Entry<Enchantment, Integer> entry : meta.getEnchants().entrySet()) {
+                Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
                 enchants.add(name);
             }
         }
 
         return enchants;
+    }
+
+    public static Component enchantmentDataToComponent(@NotNull Enchantment enchantment, @NotNull Integer level) {
+        Component name;
+        try {
+            name = plugin.getPlatform().getTranslation(enchantment);
+        } catch (Throwable throwable) {
+            name = MsgUtil.setHandleFailedHover(null, Component.text(enchantment.getKey().getKey()));
+            plugin.logger().warn("Failed to handle translation for Enchantment {}", enchantment.getKey(), throwable);
+        }
+        if (level > 1) {
+            name.append(Component.text(" " + RomanNumber.toRoman(level)));
+        }
+        return name;
     }
 
     public static boolean useEnchantmentForEnchantedBook() {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -497,12 +497,26 @@ public class Util {
         return PlainTextComponentSerializer.plainText().serialize(component).isBlank();
     }
 
+    /**
+     * Find a string in a component
+     *
+     * @param component The component to check
+     * @param find The string to check for
+     * @return A boolean of whether the component contains the string
+     */
     @NotNull
     public static boolean findStringInComponent(@NotNull Component component, @NotNull String find) {
         String plainText = PlainTextComponentSerializer.plainText().serialize(component).toLowerCase();
         return plainText.replace(' ', '_').contains(find.toLowerCase());
     }
 
+    /**
+     * Check for a string in a List of Components
+     *
+     * @param components A List<Component> of the components to check
+     * @param find The string to look for amongst the components
+     * @return A boolean of whether the string was found in the list of components
+     */
     @NotNull
     public static boolean findStringInList(@NotNull List<Component> components, @NotNull String find) {
         for (Component name : components) {
@@ -542,6 +556,13 @@ public class Util {
         return enchants;
     }
 
+    /**
+     * Take enchantment and level and turn the Name and Level into a Component
+     *
+     * @param enchantment The enchantment to get the name of
+     * @param level The numeric level of the enchantment
+     * @return A component with the name of the Enchantment and it's Level as Roman Numerals
+     */
     public static Component enchantmentDataToComponent(@NotNull Enchantment enchantment, @NotNull Integer level) {
         Component name;
         try {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -497,6 +497,55 @@ public class Util {
         return PlainTextComponentSerializer.plainText().serialize(component).isBlank();
     }
 
+    @NotNull
+    public static boolean findStringInComponent(@NotNull Component component, @NotNull String find) {
+        String plainText = PlainTextComponentSerializer.plainText().serialize(component).toLowerCase();
+        return plainText.replace(' ', '_').contains(find.toLowerCase());
+    }
+
+    @NotNull
+    public static boolean findStringInList(@NotNull List<Component> components, @NotNull String find) {
+        for (Component name : components) {
+            if (findStringInComponent(name, find))
+                return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get all enchants that can be found on an item stack
+     *
+     * @param itemStack The enchanted item
+     * @return The names of enchants contained on the enchanted item with levels
+     */
+    @NotNull
+    public static List<Component> getEnchantsForItemStack(@NotNull ItemStack itemStack) {
+        List<Component> enchants = new ArrayList<>();
+        if (!itemStack.hasItemMeta()) {
+            return enchants;
+        }
+
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta instanceof EnchantmentStorageMeta enchantmentStorageMeta && enchantmentStorageMeta.hasStoredEnchants()) {
+            for (Map.Entry<Enchantment, Integer> entry : enchantmentStorageMeta.getStoredEnchants().entrySet()) {
+                Component name;
+                try {
+                    name = plugin.getPlatform().getTranslation(entry.getKey());
+                } catch (Throwable throwable) {
+                    name = MsgUtil.setHandleFailedHover(null, Component.text(entry.getKey().getKey().getKey()));
+                    plugin.logger().warn("Failed to handle translation for Enchantment {}", entry.getKey().getKey(), throwable);
+                }
+                if (entry.getValue() > 1) {
+                    name.append(Component.text(" " + RomanNumber.toRoman(entry.getValue())));
+                }
+                enchants.add(name);
+            }
+        }
+
+        return enchants;
+    }
+
     public static boolean useEnchantmentForEnchantedBook() {
         return plugin.getConfig().getBoolean("shop.use-enchantment-for-enchanted-book");
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -566,18 +566,8 @@ public class Util {
             throw new IllegalArgumentException("Item does not have an enchantment!");
         }
         final Entry<Enchantment, Integer> entry = meta.getStoredEnchants().entrySet().iterator().next();
-        Component name;
-        try {
-            name = plugin.getPlatform().getTranslation(entry.getKey());
-        } catch (Throwable throwable) {
-            name = MsgUtil.setHandleFailedHover(null, Component.text(entry.getKey().getKey().getKey()));
-            plugin.logger().warn("Failed to handle translation for Enchantment {}", entry.getKey().getKey(), throwable);
-        }
-        if (entry.getValue() == 1 && entry.getKey().getMaxLevel() == 1) {
-            return name;
-        } else {
-            return name.append(Component.text(" " + RomanNumber.toRoman(entry.getValue())));
-        }
+        Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
+        return name;
     }
 
     public static int getItemTotalAmountsInMap(@NotNull Map<Integer, ItemStack> map) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -506,7 +506,7 @@ public class Util {
      */
     @NotNull
     public static boolean findStringInComponent(@NotNull Component component, @NotNull String find) {
-        String plainText = PlainTextComponentSerializer.plainText().serialize(component).toLowerCase();
+        final String plainText = PlainTextComponentSerializer.plainText().serialize(component).toLowerCase();
         return plainText.replace(' ', '_').contains(find.toLowerCase());
     }
 
@@ -535,20 +535,20 @@ public class Util {
      */
     @NotNull
     public static List<Component> getEnchantsForItemStack(@NotNull ItemStack itemStack) {
-        List<Component> enchants = new ArrayList<>();
+        final List<Component> enchants = new ArrayList<>();
         if (!itemStack.hasItemMeta()) {
             return enchants;
         }
 
-        ItemMeta meta = itemStack.getItemMeta();
+        final ItemMeta meta = itemStack.getItemMeta();
         if (meta instanceof EnchantmentStorageMeta enchantmentStorageMeta && enchantmentStorageMeta.hasStoredEnchants()) {
             for (Map.Entry<Enchantment, Integer> entry : enchantmentStorageMeta.getStoredEnchants().entrySet()) {
-                Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
+                final Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
                 enchants.add(name);
             }
         } else {
             for (Map.Entry<Enchantment, Integer> entry : meta.getEnchants().entrySet()) {
-                Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
+                final Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
                 enchants.add(name);
             }
         }
@@ -587,8 +587,7 @@ public class Util {
             throw new IllegalArgumentException("Item does not have an enchantment!");
         }
         final Entry<Enchantment, Integer> entry = meta.getStoredEnchants().entrySet().iterator().next();
-        Component name = enchantmentDataToComponent(entry.getKey(), entry.getValue());
-        return name;
+        return enchantmentDataToComponent(entry.getKey(), entry.getValue());
     }
 
     public static int getItemTotalAmountsInMap(@NotNull Map<Integer, ItemStack> map) {


### PR DESCRIPTION
This feature allows users to use `/qs find` to search for enchantments on both Enchanted Books and Gear such as Swords, Pickaxes and Armour.

I previously made this for [PotatoCraft-Studio/QuickShop-Reremake](https://github.com/PotatoCraft-Studio/QuickShop-Reremake) and have seen it get a lot of use on minecraft servers.

An example of its usage would be a shop selling a Diamond Sword with Sharpness 5, performing `/qs find sharpness` would direct you towards that shop, it is a very useful tool for servers that have large market areas, where just searching for Enchanted Book is not good enough and the option that allows just the first Enchantment is equally not good enough for multi-enchant books, as well as when you wish to find upgraded gear being sold at said market places.