### PR TITLE
Fix Towny town and nation account lookup when using Essentials UUID conversion

### DIFF
--- a/compatibility/towny/src/main/java/com/ghostchu/quickshop/compatibility/towny/compat/essentials/EssentialsConversion.java
+++ b/compatibility/towny/src/main/java/com/ghostchu/quickshop/compatibility/towny/compat/essentials/EssentialsConversion.java
@@ -12,13 +12,13 @@ public class EssentialsConversion implements UuidConversion {
     @Override
     public UUID convertTownyAccount(Town town) {
         String vaultAccountName = processAccount(town.getAccount().getName());
-        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + vaultAccountName).getBytes(StandardCharsets.UTF_8));
+        return UUID.nameUUIDFromBytes(("NPC:" + vaultAccountName).getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public UUID convertTownyAccount(Nation nation) {
         String vaultAccountName = processAccount(nation.getAccount().getName());
-        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + vaultAccountName).getBytes(StandardCharsets.UTF_8));
+        return UUID.nameUUIDFromBytes(("NPC:" + vaultAccountName).getBytes(StandardCharsets.UTF_8));
     }
 
     private String processAccount(String accountName) {


### PR DESCRIPTION
Towny accounts under Essentials Economy are created as NPC accounts. As such, they are prefixed with `NPC:` instead of `OfflinePlayer:`. 

See https://github.com/EssentialsX/Essentials/blob/b54c8c1774e95c025c521cafcc5be9c49466ca13/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java#L53.