### PR TITLE
Fix tab-completion for commands

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/QuickShopCommand.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/QuickShopCommand.java
@@ -28,11 +28,11 @@ public class QuickShopCommand extends BukkitCommand {
   @NotNull
   @Override
   public List<String> tabComplete(@NotNull final CommandSender sender, @NotNull final String alias, @NotNull final String[] args) throws IllegalArgumentException {
-
     List<String> items = this.manager.onTabComplete(sender, this, alias, args);
     if(items == null) {
-      items = Bukkit.getOnlinePlayers().stream().map(Player::getName).toList();
+      return super.tabComplete(sender, alias, args);
     }
+
     return items;
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
@@ -76,12 +76,14 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -632,8 +634,13 @@ public class SimpleCommandManager implements CommandManager, TabCompleter, Comma
         if(Util.isDevMode()) {
           Log.debug("Tab-complete container: " + container.getPrefix());
         }
-        return container.getExecutor().onTabComplete_Internal(capture(sender), commandLabel, passThroughArgs);
 
+        List<String> generatedCompletions = container.getExecutor().onTabComplete_Internal(capture(sender), commandLabel, passThroughArgs);
+        if (generatedCompletions != null) {
+          return StringUtil.copyPartialMatches(cmdArg[cmdArg.length - 1], generatedCompletions, new ArrayList<>());
+        }
+
+        return null;
       }
       return Collections.emptyList();
     }


### PR DESCRIPTION
**Two small changes for command tab-completion:**
- when no tab completions are returned by a command / subcommand, the default completions (player list) is returned. The difference is that now players with vanish can't be completed in those commands, and we're using the original method
- fix completions not matching input being returned (video)

https://github.com/user-attachments/assets/e00325aa-5694-4ba4-a6a8-6d43e5f34690
