### PR TITLE
Changed event-priority of BlockListener#onBreak to MONITOR

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/BlockListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/BlockListener.java
@@ -54,7 +54,7 @@ public class BlockListener extends AbstractProtectionListener {
   /*
    * Removes chests when they're destroyed.
    */
-  @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onBreak(final BlockBreakEvent e) {
 
     final Block b = e.getBlock();


### PR DESCRIPTION
See https://github.com/QuickShop-Community/QuickShop-Hikari/issues/1790