### PR TITLE
Add final earning placeholder to records in history menu

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/history/MainPage.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/menu/history/MainPage.java
@@ -245,7 +245,8 @@ public class MainPage {
                                                userName,
                                                itemName, record.amount(),
                                                record.money(),
-                                               record.tax());
+                                               record.tax(),
+                                               record.money() - record.tax());
 
           final String timeFormat = QuickShop.getInstance().text().of(player, "timeunit.std-format").plain();
           final SimpleDateFormat format = new SimpleDateFormat(timeFormat);

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -1870,6 +1870,7 @@ history:
       - "<white>Item: <yellow>{2} <aqua>x{3}</aqua></yellow></white>"
       - "<white>Balance: <yellow>{4}</yellow></white>"
       - "<white>Tax: <yellow>{5}</yellow></white>"
+      - "<white>Final earning: <yellow>{6}</yellow></white>"
     query-icon: "<gray>Please wait, querying...</gray>"
     previous-page: "<white><< Previous Page</white>"
     next-page: "<white>Next Page >></white>"


### PR DESCRIPTION
Adds the ability to display the final earning in the history browser, i.e. (income - tax)