### PR TITLE
EnvironmentChecker#virtualDisplayWorkingTest no longer fails if dispays are either disabled, or not of type virtual

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -357,10 +357,10 @@ public final class EnvironmentChecker {
   public ResultContainer virtualDisplaySupportTest() {
 
     if(!plugin.isDisplayEnabled()) {
-      return new ResultContainer(CheckResult.PASSED, "The display are disabled.");
+      return new ResultContainer(CheckResult.PASSED, "The setting shop.display-items is disabled.");
     }
     if(AbstractDisplayItem.getNowUsing() != DisplayType.VIRTUALITEM) {
-      return new ResultContainer(CheckResult.PASSED, "The display type is not virtual item.");
+      return new ResultContainer(CheckResult.PASSED, "The setting shop.display-type is not virtual item.");
     }
     if(!plugin.getGameVersion().isVirtualDisplaySupports()) {
       AbstractDisplayItem.setVirtualDisplayDoesntWork(true);
@@ -378,10 +378,10 @@ public final class EnvironmentChecker {
   public ResultContainer virtualDisplayWorkingTest() {
 
     if(!plugin.isDisplayEnabled()) {
-      return new ResultContainer(CheckResult.PASSED, "The display are disabled.");
+      return new ResultContainer(CheckResult.PASSED, "The setting shop.display-items is disabled.");
     }
     if(AbstractDisplayItem.getNowUsing() != DisplayType.VIRTUALITEM) {
-      return new ResultContainer(CheckResult.PASSED, "The display type is not virtual item.");
+      return new ResultContainer(CheckResult.PASSED, "The setting shop.display-type is not virtual item.");
     }
     if(plugin.getVirtualDisplayItemManager() == null) {
       AbstractDisplayItem.setVirtualDisplayDoesntWork(true);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/envcheck/EnvironmentChecker.java
@@ -377,6 +377,12 @@ public final class EnvironmentChecker {
   @EnvCheckEntry(name = "Virtual DisplayItem Support Test", priority = 7, stage = EnvCheckEntry.Stage.AFTER_ON_ENABLE)
   public ResultContainer virtualDisplayWorkingTest() {
 
+    if(!plugin.isDisplayEnabled()) {
+      return new ResultContainer(CheckResult.PASSED, "The display are disabled.");
+    }
+    if(AbstractDisplayItem.getNowUsing() != DisplayType.VIRTUALITEM) {
+      return new ResultContainer(CheckResult.PASSED, "The display type is not virtual item.");
+    }
     if(plugin.getVirtualDisplayItemManager() == null) {
       AbstractDisplayItem.setVirtualDisplayDoesntWork(true);
       return new ResultContainer(CheckResult.WARNING, "VirtualDisplayItemManager is null, this shouldn't happen, contact with QuickShop-Hikari developer.");


### PR DESCRIPTION
A user reported that they've seen the warning log-entry, as printed by this environment-check, namely

```
VirtualDisplayItemManager is null, this shouldn't happen, contact with QuickShop-Hikari developer.
```

even though they've disabled displays altogether, by setting `shop.display-items` to false; this is undesired behavior. My commit simply mimics the checks as performed by it's line-relative predecessor `virtualDisplaySupportTest`, as to pass if displays are disabled, or not of type virtual.