### PR TITLE
Update retired paper endpoints

### DIFF
--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -35,7 +35,7 @@
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -56,7 +56,7 @@
         </repository>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>CodeMC</id>

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -31,7 +31,7 @@
         </repository>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Paper removed the legacy endpoints on December 31, 2024. This PR updates them to the new endpoints.