### PR TITLE
Security fixes in plugin messaging

### DIFF
--- a/compatibility/bungeecord-geyser/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord.geyser/Main.java
+++ b/compatibility/bungeecord-geyser/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord.geyser/Main.java
@@ -2,6 +2,7 @@ package com.ghostchu.quickshop.compatibility.bungeecord.geyser;
 
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
+import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.ServerConnectedEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.api.plugin.Plugin;
@@ -37,6 +38,16 @@ public final class Main extends Plugin implements Listener {
     this.pendingForward.clear();
     getProxy().getPluginManager().unregisterListener(this);
     getProxy().unregisterChannel(BUNGEE_CHANNEL);
+  }
+
+  @EventHandler
+  public void on(final PluginMessageEvent event) {
+    // Is this our business?
+    if(!BUNGEE_CHANNEL.equalsIgnoreCase(event.getTag())) {
+      return;
+    }
+    // Let's not be a snitch
+    event.setCancelled(true);
   }
 
   @EventHandler

--- a/compatibility/bungeecord-geyser/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord.geyser/Main.java
+++ b/compatibility/bungeecord-geyser/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord.geyser/Main.java
@@ -47,6 +47,8 @@ public final class Main extends Plugin implements Listener {
       return;
     }
     // Let's not be a snitch
+    // we don't want the client to send any message to the server
+    // nor do we want the proxy to send any message to the player
     event.setCancelled(true);
   }
 

--- a/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
+++ b/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
@@ -51,10 +51,14 @@ public final class Main extends Plugin implements Listener {
       return;
     }
     // Let's not be a snitch
+    // we don't want the client to send any message to the server
+    // nor do we want the proxy to send any message to the player
     event.setCancelled(true);
     // Is the source correct?
+    // we can only trust the server not the player
     if (!(event.getSender() instanceof Server)) return; // Somebody is being nasty
     // We can trust the source
+    // server sent us the message
     final ByteArrayDataInput in = ByteStreams.newDataInput(event.getData());
     final String subChannel = in.readUTF();
     if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {

--- a/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
+++ b/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
@@ -47,7 +47,7 @@ public final class Main extends Plugin implements Listener {
   @EventHandler
   public void on(final PluginMessageEvent event) {
     // Is this our business?
-    if (!QUICKSHOP_BUNGEE_CHANNEL.equalsIgnoreCase(event.getTag())) {
+    if(!QUICKSHOP_BUNGEE_CHANNEL.equalsIgnoreCase(event.getTag())) {
       return;
     }
     // Let's not be a snitch
@@ -56,12 +56,12 @@ public final class Main extends Plugin implements Listener {
     event.setCancelled(true);
     // Is the source correct?
     // we can only trust the server not the player
-    if (!(event.getSender() instanceof Server)) return; // Somebody is being nasty
+    if(!(event.getSender() instanceof Server)) return; // Somebody is being nasty
     // We can trust the source
     // server sent us the message
     final ByteArrayDataInput in = ByteStreams.newDataInput(event.getData());
     final String subChannel = in.readUTF();
-    if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
+    if(SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
       final String command = in.readUTF();
       processCommand(command, in);
     }

--- a/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
+++ b/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
@@ -51,6 +51,8 @@ public final class Main extends Plugin implements Listener {
       return;
     }
 
+    event.setCancelled(true);
+
     final ByteArrayDataInput in = ByteStreams.newDataInput(event.getData());
     final String subChannel = in.readUTF();
     if(SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {

--- a/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
+++ b/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
@@ -47,20 +47,17 @@ public final class Main extends Plugin implements Listener {
   @EventHandler
   public void on(final PluginMessageEvent event) {
 
-    if(!QUICKSHOP_BUNGEE_CHANNEL.equalsIgnoreCase(event.getTag())) {
+    if (!QUICKSHOP_BUNGEE_CHANNEL.equalsIgnoreCase(event.getTag())) {
       return;
     }
-
     event.setCancelled(true);
-
+    // the sender is a server when the proxy talks to a server
+    if (!(event.getSender() instanceof Server)) return;
     final ByteArrayDataInput in = ByteStreams.newDataInput(event.getData());
     final String subChannel = in.readUTF();
-    if(SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
-      // the receiver is a server when the proxy talks to a server
-      if(event.getSender() instanceof Server) {
-        final String command = in.readUTF();
-        processCommand(command, in);
-      }
+    if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
+      final String command = in.readUTF();
+      processCommand(command, in);
     }
   }
 

--- a/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
+++ b/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
@@ -55,7 +55,7 @@ public final class Main extends Plugin implements Listener {
     final String subChannel = in.readUTF();
     if(SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
       // the receiver is a server when the proxy talks to a server
-      if(event.getReceiver() instanceof Server) {
+      if(event.getSender() instanceof Server) {
         final String command = in.readUTF();
         processCommand(command, in);
       }

--- a/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
+++ b/compatibility/bungeecord/src/main/java/com/ghostchu/quickshop/compatibility/bungeecord/Main.java
@@ -46,13 +46,15 @@ public final class Main extends Plugin implements Listener {
 
   @EventHandler
   public void on(final PluginMessageEvent event) {
-
+    // Is this our business?
     if (!QUICKSHOP_BUNGEE_CHANNEL.equalsIgnoreCase(event.getTag())) {
       return;
     }
+    // Let's not be a snitch
     event.setCancelled(true);
-    // the sender is a server when the proxy talks to a server
-    if (!(event.getSender() instanceof Server)) return;
+    // Is the source correct?
+    if (!(event.getSender() instanceof Server)) return; // Somebody is being nasty
+    // We can trust the source
     final ByteArrayDataInput in = ByteStreams.newDataInput(event.getData());
     final String subChannel = in.readUTF();
     if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {

--- a/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
+++ b/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
@@ -125,7 +125,7 @@ public final class Main {
   @Subscribe
   public void on(final PluginMessageEvent event) {
     // Is this our business?
-    if (!QUICKSHOP_BUNGEE_CHANNEL.equals(event.getIdentifier())) {
+    if(!QUICKSHOP_BUNGEE_CHANNEL.equals(event.getIdentifier())) {
       return;
     }
     // Let's not be a snitch
@@ -134,12 +134,12 @@ public final class Main {
     event.setResult(PluginMessageEvent.ForwardResult.handled());
     // Is the source correct?
     // we can only trust the server not the player
-    if (!(event.getSource() instanceof ServerConnection)) return;
+    if(!(event.getSource() instanceof ServerConnection)) return;
     // We can trust the source
     // server sent us the message
     final ByteArrayDataInput in = event.dataAsDataStream();
     final String subChannel = in.readUTF();
-    if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
+    if(SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
       final String command = in.readUTF();
       processCommand(command, in);
     }

--- a/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
+++ b/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
@@ -129,10 +129,14 @@ public final class Main {
       return;
     }
     // Let's not be a snitch
+    // we don't want the client to send any message to the server
+    // nor do we want the proxy to send any message to the player
     event.setResult(PluginMessageEvent.ForwardResult.handled());
     // Is the source correct?
+    // we can only trust the server not the player
     if (!(event.getSource() instanceof ServerConnection)) return;
     // We can trust the source
+    // server sent us the message
     final ByteArrayDataInput in = event.dataAsDataStream();
     final String subChannel = in.readUTF();
     if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {

--- a/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
+++ b/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
@@ -125,18 +125,17 @@ public final class Main {
   @Subscribe
   public void on(final PluginMessageEvent event) {
 
-    if(!QUICKSHOP_BUNGEE_CHANNEL.equals(event.getIdentifier())) {
+    if (!QUICKSHOP_BUNGEE_CHANNEL.equals(event.getIdentifier())) {
       return;
     }
     event.setResult(PluginMessageEvent.ForwardResult.handled());
+    // the source is a server when the proxy talks to a server
+    if (!(event.getSource() instanceof ServerConnection)) return;
     final ByteArrayDataInput in = event.dataAsDataStream();
     final String subChannel = in.readUTF();
-    if(SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
-      // the receiver is a server when the proxy talks to a server
-      if(event.getSource() instanceof ServerConnection) {
-        final String command = in.readUTF();
-        processCommand(command, in);
-      }
+    if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {
+      final String command = in.readUTF();
+      processCommand(command, in);
     }
   }
 

--- a/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
+++ b/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
@@ -124,13 +124,15 @@ public final class Main {
 
   @Subscribe
   public void on(final PluginMessageEvent event) {
-
+    // Is this our business?
     if (!QUICKSHOP_BUNGEE_CHANNEL.equals(event.getIdentifier())) {
       return;
     }
+    // Let's not be a snitch
     event.setResult(PluginMessageEvent.ForwardResult.handled());
-    // the source is a server when the proxy talks to a server
+    // Is the source correct?
     if (!(event.getSource() instanceof ServerConnection)) return;
+    // We can trust the source
     final ByteArrayDataInput in = event.dataAsDataStream();
     final String subChannel = in.readUTF();
     if (SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {

--- a/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
+++ b/compatibility/velocity/src/main/java/com/ghostchu/quickshop/compatibility/velocity/Main.java
@@ -128,6 +128,7 @@ public final class Main {
     if(!QUICKSHOP_BUNGEE_CHANNEL.equals(event.getIdentifier())) {
       return;
     }
+    event.setResult(PluginMessageEvent.ForwardResult.handled());
     final ByteArrayDataInput in = event.dataAsDataStream();
     final String subChannel = in.readUTF();
     if(SUB_CHANNEL_COMMAND.equalsIgnoreCase(subChannel)) {


### PR DESCRIPTION
Major changes: 
1) bungeecord-addon: before wrong sender check
2) handling plugin messages on the proxy so that the messages are not getting forwarded to the respective sinks