### PR TITLE
Fix about freeze mode

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -989,6 +989,9 @@ public class ContainerShop implements Shop, Reloadable {
     if(isBuying()) {
       return getRemainingSpace() > 0;
     }
+    if(isFrozen()) {
+      return getRemainingSpace() > 0;
+    }
     return true;
   }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -842,7 +842,7 @@ public class ContainerShop implements Shop, Reloadable {
       case FROZEN -> {
         shopRemaining = 0;
         tradingStringKey = "signs.freeze";
-        noRemainingStringKey = "signs.out-of-stock";
+        noRemainingStringKey = "signs.freeze";
       }
       default -> {
         shopRemaining = 0;
@@ -990,7 +990,7 @@ public class ContainerShop implements Shop, Reloadable {
       return getRemainingSpace() > 0;
     }
     if(isFrozen()) {
-      return getRemainingSpace() > 0;
+      return false;
     }
     return true;
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/controlpanel/component/FreezeComponent.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/controlpanel/component/FreezeComponent.java
@@ -75,7 +75,7 @@ public class FreezeComponent implements ControlComponent {
   @Override
   public Component generate(final @NotNull QuickShopAPI plugin, final @NotNull Player sender, final @NotNull Shop shop) {
 
-    final Component text = ((QuickShop)plugin).text().of(sender, "controlpanel.frozen", MsgUtil.bool2String(shop.isFrozen())).forLocale();
+    final Component text = ((QuickShop)plugin).text().of(sender, "controlpanel.freeze", MsgUtil.bool2String(shop.isFrozen())).forLocale();
 
     final Component hoverText = ((QuickShop)plugin).text().of(sender, "controlpanel.freeze-hover").forLocale();
     final String clickCommand = MsgUtil.fillArgs("/{0} {1} {2}", ((QuickShop)plugin).getMainCommand(), ((QuickShop)plugin).getCommandPrefix("silentfreeze"), shop.getRuntimeRandomUniqueId().toString());

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/controlpanel/component/FreezeComponent.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/controlpanel/component/FreezeComponent.java
@@ -75,8 +75,7 @@ public class FreezeComponent implements ControlComponent {
   @Override
   public Component generate(final @NotNull QuickShopAPI plugin, final @NotNull Player sender, final @NotNull Shop shop) {
 
-    final String path = shop.isFrozen()? "controlpanel.unfreeze" : "controlpanel.freeze";
-    final Component text = ((QuickShop)plugin).text().of(sender, path, MsgUtil.bool2String(shop.isFrozen())).forLocale();
+    final Component text = ((QuickShop)plugin).text().of(sender, "controlpanel.frozen", MsgUtil.bool2String(shop.isFrozen())).forLocale();
 
     final Component hoverText = ((QuickShop)plugin).text().of(sender, "controlpanel.freeze-hover").forLocale();
     final String clickCommand = MsgUtil.fillArgs("/{0} {1} {2}", ((QuickShop)plugin).getMainCommand(), ((QuickShop)plugin).getCommandPrefix("silentfreeze"), shop.getRuntimeRandomUniqueId().toString());

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -437,7 +437,7 @@ controlpanel:
     container's content.
   alwayscounting: '<green>Always counting: {0} <yellow>[<bold><light_purple>Change</light_purple></bold>]'
   setowner: '<green>Owner: <aqua>{0} <yellow>[<bold><light_purple>Change</light_purple></bold>]'
-  freeze: '<yellow>Freeze mode: <aqua>{0} <yellow>[<bold><light_purple>Toggle</light_purple></bold>]'
+  freeze: '<green>Freeze mode: <aqua>{0} <yellow>[<bold><light_purple>Toggle</light_purple></bold>]'
   price: '<green>Price: <aqua>{0} <yellow>[<bold><light_purple>Change</light_purple></bold>]'
   currency-hover: <yellow>Click to set or remove the currency that this shop is using
   lock: '<yellow>Shop lock: <aqua>{0} <yellow>[<bold><light_purple>Toggle</light_purple></bold>]'


### PR DESCRIPTION
## Fixes
- Display error when switching freeze mode in Shop ControlPanel
- Freeze mode in ControlPanel does not match the colours of other modes
## Improvements
- The shop owner now turns red when the shop is in freeze mode
- Modify the contents of shop signs in freeze mode