### PR TITLE
improve freeze mode

### DIFF
--- a/addon/list/src/main/java/com/ghostchu/quickshop/addon/list/command/SubCommand_List.java
+++ b/addon/list/src/main/java/com/ghostchu/quickshop/addon/list/command/SubCommand_List.java
@@ -119,8 +119,10 @@ public class SubCommand_List implements CommandHandler<Player> {
       final Component shopTypeComponent;
       if(shop.isBuying()) {
         shopTypeComponent = quickshop.text().of(sender, "menu.this-shop-is-buying").forLocale();
-      } else {
+      } else if(shop.isSelling()) {
         shopTypeComponent = quickshop.text().of(sender, "menu.this-shop-is-selling").forLocale();
+      } else {
+        shopTypeComponent = quickshop.text().of(sender, "menu.this-shop-is-frozen").forLocale();
       }
       Component component = quickshop.text().of(sender, "addon.list.entry", counter, shopNameComponent, location.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ(), quickshop.getEconomy().format(shop.getPrice(), shop.getLocation().getWorld(), shop.getCurrency()), shop.getShopStackingAmount(), Util.getItemStackName(shop.getItem()), shopTypeComponent).forLocale();
       component = component.clickEvent(ClickEvent.runCommand(MsgUtil.fillArgs("/{0} {1} {2}", quickshop.getMainCommand(), quickshop.getCommandPrefix("silentpreview"), shop.getRuntimeRandomUniqueId().toString())));

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
@@ -177,7 +177,6 @@ public class SimpleCommandManager implements CommandManager, TabCompleter, Comma
     registerCmd(
             CommandContainer.builder()
                     .prefix("freeze")
-                    .hidden(true)
                     .permission("quickshop.togglefreeze")
                     .executor(new SubCommand_Freeze(plugin))
                     .build());

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Freeze.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Freeze.java
@@ -10,6 +10,9 @@ import com.ghostchu.quickshop.util.Util;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
+import java.util.List;
+
 public class SubCommand_Freeze implements CommandHandler<Player> {
 
   private final QuickShop plugin;
@@ -25,7 +28,7 @@ public class SubCommand_Freeze implements CommandHandler<Player> {
     final Shop shop = getLookingShop(sender);
     if(shop != null) {
       if(shop.playerAuthorize(sender.getUniqueId(), BuiltInShopPermission.SET_SHOPTYPE)
-         || plugin.perm().hasPermission(sender, "quickshop.other.buy")) {
+              || plugin.perm().hasPermission(sender, "quickshop.other.freeze")) {
 
         if(shop.getShopType().equals(ShopType.FROZEN)) {
 
@@ -44,5 +47,13 @@ public class SubCommand_Freeze implements CommandHandler<Player> {
       return;
     }
     plugin.text().of(sender, "not-looking-at-shop").send();
+  }
+
+  @NotNull
+  @Override
+  public List<String> onTabComplete(
+          @NotNull final Player sender, @NotNull final String commandLabel, @NotNull final CommandParser parser) {
+
+    return Collections.emptyList();
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentFreeze.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/silent/SubCommand_SilentFreeze.java
@@ -22,23 +22,24 @@ public class SubCommand_SilentFreeze extends SubCommand_SilentBase {
   protected void doSilentCommand(final Player sender, @NotNull final Shop shop, @NotNull final CommandParser parser) {
 
     if(!shop.playerAuthorize(sender.getUniqueId(), BuiltInShopPermission.SET_SHOPTYPE)
-       && !plugin.perm().hasPermission(sender, "quickshop.create.admin")) {
+            && !plugin.perm().hasPermission(sender, "quickshop.create.admin")) {
       plugin.text().of(sender, "not-permission").send();
       return;
     }
 
-    if(shop.getShopType().equals(ShopType.FROZEN)) {
 
+    MsgUtil.sendControlPanelInfo(sender, shop);
+
+
+    if(shop.getShopType().equals(ShopType.FROZEN)) {
       shop.setShopType(ShopType.BUYING);
       plugin.text().of(sender, "shop-nolonger-freezed", Util.getItemStackName(shop.getItem())).send();
       plugin.text().of(sender, "command.now-buying", Util.getItemStackName(shop.getItem())).send();
     } else {
-
-
       shop.setShopType(ShopType.FROZEN);
       plugin.text().of(sender, "shop-now-freezed", Util.getItemStackName(shop.getItem())).send();
     }
+
     shop.setSignText(plugin.text().findRelativeLanguages(sender));
-    MsgUtil.sendControlPanelInfo(sender, shop);
   }
 }

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -156,6 +156,7 @@ menu:
   item-holochat-data-too-large: <red>[Error] Item NBT is too large to display
   stock: '<green>Stock: <yellow>{0}'
   this-shop-is-buying: <green>This shop is <light_purple>BUYING<green> items.
+  this-shop-is-frozen: <green>The shop is now in <red>freeze mode<green>.
   successfully-sold: '<green>Successfully sold:'
   total-value-of-chest: '<green>Total value of chest: <yellow>{0}'
 currency-not-exists: <red>Cannot find the currency that you want to set. Maybe the

--- a/quickshop-bukkit/src/main/resources/plugin.yml
+++ b/quickshop-bukkit/src/main/resources/plugin.yml
@@ -175,6 +175,9 @@ permissions:
   quickshop.create.buy:
     description: Allows a player to buy from a shop.
     default: op
+  quickshop.togglefreeze:
+      description: Allows a player switch shop type to frozen mode.
+      default: op
   quickshop.create.double:
     description: Allows a player to create a double shop.
     default: op
@@ -381,6 +384,15 @@ permissions:
     default: op
   quickshop.other.history:
     description: Permission to view the other's shop history
+    default: op
+  quickshop.other.sell:
+    description: Allows a other player force switch the shop type to sell mode
+    default: op
+  quickshop.other.buy:
+    description: Allows a other player force switch the shop type to buy mode
+    default: op
+  quickshop.other.freeze:
+    description: Allows a other player force switch the shop type to frozen mode
     default: op
   quickshop.suggestprice:
     description: Suggest the shop recommend price


### PR DESCRIPTION
- add a check for freeze mode shop to the List Addon.
- fix /qs freeze can't use tab completion
- fix permission misspelling.  
- add some permission description
- adjusting the order in which messages are send

Simple test, everything seems to be working
![495884ce-81a4-4c5b-8e06-b8844d6d8080](https://github.com/user-attachments/assets/47ff2742-a3ba-4815-ad5c-f45dd9058e7a)
![838c1e01-c66e-44a9-9d6a-695388ac62cd](https://github.com/user-attachments/assets/7bf4e668-7a71-493a-a9f3-ebb4c00e307e)
