### PR TITLE
Fix ShopCreateEvent POST phase being called twice

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -646,7 +646,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
         loadShop(shop);
         shop.setSignText(plugin.getTextManager().findRelativeLanguages(p));
 
-        event = event.clone(Phase.POST);
+        event = event.clone(Phase.MAIN);
         event.callEvent();
       }
     }


### PR DESCRIPTION
The POST phase for ShopCreateEvent is called twice:
- `SimpleShopManager#createShop:649` (before shop is registered in the database)
- `AbstractShopManager#registrerShop:484` (after shop is registered in the database)

I decided to change the call in shop manager to MAIN phase, because at this point shop is not fully registered into the database yet and it could be rolled back if some exception is thrown in `registerShop`