### PR TITLE
Fix shops are not properly unregistered after being deleted

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
@@ -201,6 +201,7 @@ public abstract class AbstractShopManager implements ShopManager {
     }
     inChunk.remove(loc);
     shopCache.invalidate(null, shop.getLocation());
+    shopRuntimeUUIDCaching.invalidate(shop.getRuntimeRandomUniqueId());
   }
 
 


### PR DESCRIPTION
Shops are not removed from `UUID -> Shop` map in `AbstractShopManager` after being deleted.

This could cause some bugs, for example player could currently delete the shop unlimited times, even though the shop doesn't exist, the entire deletion code is executed just as normal