### PR TITLE
Clone item when calling getItem()

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -517,7 +517,7 @@ public class ContainerShop implements Shop, Reloadable {
   @Override
   public @NotNull ItemStack getItem() {
 
-    final ShopItemEvent event = new ShopItemEvent(Phase.RETRIEVE, this, this.item);
+    final ShopItemEvent event = new ShopItemEvent(Phase.RETRIEVE, this, this.item.clone());
 
     return event.updated();
   }


### PR DESCRIPTION
ContainerShop#getItem() should clone the item to prevent unwanted mutations to the item. This was added as the preview menu will add the 'no-grab' tag to the item, breaking any shop item with metadata.