### PR TITLE
Add permission for shop self-trade

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -180,6 +180,11 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
       return false;
     }
 
+    if (shop.getOwner().getUniqueId() != null && shop.getOwner().getUniqueId().equals(buyer.getUniqueId()) && !plugin.perm().hasPermission(buyer, "quickshop.self-trade")) {
+      plugin.text().of(buyer, "shop-owner-self-trade-denied").send();
+      return false;
+    }
+
     if(shop.isFrozen()) {
       plugin.text().of(buyer, "shop-cannot-trade-when-freezing").send();
       return false;
@@ -375,6 +380,12 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
       plugin.text().of("no-permission").send();
       return false;
     }
+
+    if (shop.getOwner().getUniqueId() != null && shop.getOwner().getUniqueId().equals(seller.getUniqueId()) && !plugin.perm().hasPermission(seller, "quickshop.self-trade")) {
+      plugin.text().of(seller, "shop-owner-self-trade-denied").send();
+      return false;
+    }
+
     if(shopIsNotValid(sellerQUser, info, shop)) {
       return false;
     }

--- a/quickshop-bukkit/src/main/resources/lang/messages.yml
+++ b/quickshop-bukkit/src/main/resources/lang/messages.yml
@@ -113,6 +113,7 @@ success-created-shop: <green>Shop successfully created.
 shop-creation-cancelled: <red>The shop creation was cancelled.
 shop-owner-self-trade: <yellow>You're trading with your own shop. <gray>You may not
   gain any money.
+shop-owner-self-trade-denied: <red>You cannot trade with your own shop.
 purchase-out-of-space: <red>This shop has run out of space! Contact the shop owner
   or staff to get it emptied.
 reloading-status:

--- a/quickshop-bukkit/src/main/resources/plugin.yml
+++ b/quickshop-bukkit/src/main/resources/plugin.yml
@@ -397,3 +397,6 @@ permissions:
   quickshop.suggestprice:
     description: Suggest the shop recommend price
     default: op
+  quickshop.self-trade:
+    description: Allows a player to trade with their own shops
+    default: true


### PR DESCRIPTION
This pull request adds a new permission for 'self-trade' to be enabled or disabled via a permission node.

**New Permission Node**: `quickshop.self-trade` Permission is enabled by default for backwards compatibility
**New Lang Message**: `shop-owner-self-trade-denied` Sent when a player is denied self-trading.

Video of implemented feature: https://youtu.be/Lfedq0c3wZo