### PR TITLE
Fix Hopper Enabled State Being Incorrectly Reset on Placement

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/ShopProtectionListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/ShopProtectionListener.java
@@ -161,6 +161,7 @@ public class ShopProtectionListener extends AbstractProtectionListener {
 
     if(e.getBlockPlaced().getState() instanceof final Hopper hopper) {
       hopper.getPersistentDataContainer().set(hopperKey, HopperPersistentDataType.INSTANCE, new HopperPersistentData(e.getPlayer().getUniqueId()));
+      hopper.setBlockData(e.getBlockPlaced().getBlockData());
       hopper.update();
     }
   }


### PR DESCRIPTION
### Problem Background

When a player places a hopper next to a powered block (such as a redstone block), its enabled state should be `false`, meaning the hopper is "disabled" and will not transfer items.     However, during the handling of the hopper placement event in the listener, it was discovered that using `e.getBlockPlaced().getState()` causes the hopper's enabled state to be incorrectly reset to its default value `true`, instead of preserving the actual state at the time of placement.

To verify this issue, we used the following test code:

- **Correct way - retrieving BlockData directly:**
```java
BlockData correctData = e.getBlockPlaced().getBlockData();
System.out.println(correctData);     // Output: CraftBlockData{minecraft:hopper[enabled=false,facing=down]}
```


- **Incorrect way - retrieving BlockData via getState():**
```java
BlockData wrongData = e.getBlockPlaced().getState().getBlockData();
System.out.println(wrongData);     // Output: CraftBlockData{minecraft:hopper[enabled=true,facing=down]}
```


These tests confirmed that calling `.getState()` leads to loss or corruption of non-default block state attributes, which results in unexpected behavior when `hopper.update()` is called afterward.

---

### Root Cause

Calling `.getState()` creates a copy of the block state based on persisted chunk data rather than the actual placed block.     This means transient properties like the enabled state of a hopper may be reset to their default values.

---

### Solution

To prevent this issue, we now use `e.getBlockPlaced().getBlockData()` directly after placement to preserve the original block state.

The key change is:

```java
hopper.setBlockData(e.getBlockPlaced().getBlockData());
```


This approach avoids incomplete copying of block state data by the server implementation and ensures the hopper retains its correct enabled/disabled state, even under redstone influence.