### PR TITLE
Fix NullPointerException caused by not set tax in 'price' command

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/economy/transaction/QSEconomyTransactionBuilder.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/economy/transaction/QSEconomyTransactionBuilder.java
@@ -98,7 +98,7 @@ public class QSEconomyTransactionBuilder {
             world,
             currency,
             amount,
-            tax,
+            tax != null ? tax : BigDecimal.ZERO,
             from,
             to,
             taxer

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/economy/transaction/QSEconomyTransactionBuilder.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/economy/transaction/QSEconomyTransactionBuilder.java
@@ -98,7 +98,7 @@ public class QSEconomyTransactionBuilder {
             world,
             currency,
             amount,
-            tax != null ? tax : BigDecimal.ZERO,
+            (tax != null)? tax : BigDecimal.ZERO,
             from,
             to,
             taxer

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -180,7 +180,6 @@ public class ShopUtil {
               .amount(BigDecimal.valueOf(fee))
               .world(Objects.requireNonNull(shop.getLocation().getWorld()).getName())
               .currency(plugin.getCurrency())
-              .tax(BigDecimal.ZERO)
               .build();
       if(!transaction.completable()) {
         plugin.text().of(user, "you-cant-afford-to-change-price", plugin.getShopManager().format(fee, shop)).send();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -180,6 +180,7 @@ public class ShopUtil {
               .amount(BigDecimal.valueOf(fee))
               .world(Objects.requireNonNull(shop.getLocation().getWorld()).getName())
               .currency(plugin.getCurrency())
+              .tax(BigDecimal.ZERO)
               .build();
       if(!transaction.completable()) {
         plugin.text().of(user, "you-cant-afford-to-change-price", plugin.getShopManager().format(fee, shop)).send();


### PR DESCRIPTION
When fee for shop price change is set (`fee > 0`), `QSEconomyTransactionBuilder#build` throws NullPointerException because the tax is not set on it. This fast-fix PR sets the tax on the builder to `BigDecimal.ZERO` which resolves the problem.