### PR TITLE
Fixed an error from /qs debug that occurred when no items were hold in the hand

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Debug.java
@@ -134,6 +134,10 @@ public class SubCommand_Debug implements CommandHandler<CommandSender> {
     if(!(sender instanceof Player player)) {
       return;
     }
+    if(player.getInventory().getItemInMainHand().getType().isAir()) {
+        plugin.text().of(sender, "no-anythings-in-your-hand").send();
+        return;
+    }
     final String hand = player.getInventory().getItemInMainHand().getItemMeta().getAsString();
     plugin.text().of(sender, "debug.item-info-hand-as-string", hand, Hashing.crc32().hashString(hand, StandardCharsets.UTF_8).toString()).send();
     final Shop shop = getLookingShop(sender);


### PR DESCRIPTION
fix
```
[13:53:46 ERROR]: Command exception: /qs debug item-info
java.lang.NullPointerException: Cannot invoke "org.bukkit.inventory.meta.ItemMeta.getAsString()" because the return value of "org.bukkit.inventory.ItemStack.getItemMeta()" is null
        at QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar/com.ghostchu.quickshop.command.subcommand.SubCommand_Debug.handleItemInfo(SubCommand_Debug.java:137) ~[QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar:?]
        at QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar/com.ghostchu.quickshop.command.subcommand.SubCommand_Debug.onCommand(SubCommand_Debug.java:123) ~[QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar:?]
        at QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar/com.ghostchu.quickshop.api.command.CommandHandler.onCommand_Internal(CommandHandler.java:88) ~[QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar:?]
        at QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar/com.ghostchu.quickshop.command.SimpleCommandManager.onCommand(SimpleCommandManager.java:538) ~[QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar:?]
        at QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar/com.ghostchu.quickshop.command.QuickShopCommand.execute(QuickShopCommand.java:23) ~[QuickShop-Hikari-6.2.0.10-SNAPSHOT-8.jar:?]
        at io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:83) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.3.10.jar:?]
        at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:29) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:103) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:437) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.commands.Commands.performCommand(Commands.java:368) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.commands.Commands.performCommand(Commands.java:357) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.performUnsignedChatCommand(ServerGamePacketListenerImpl.java:2403) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$16(ServerGamePacketListenerImpl.java:2376) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1485) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:165) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1466) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1460) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:118) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1419) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1304) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:298) ~[leaf-1.21.8.jar:1.21.8-98-d36ed6c]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```