### PR TITLE
Fix price restrictions (restore previously used subAfter behaviour)

### DIFF
--- a/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/CommonUtil.java
+++ b/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/CommonUtil.java
@@ -166,7 +166,7 @@ public class CommonUtil {
       return string;
     }
 
-    final int pos = string.lastIndexOf(separator);
+    final int pos = string.indexOf(separator);
     if(pos == -1) {
       return "";
     }


### PR DESCRIPTION
This fixes issues with price restrictions introduced in 6.2.0.11 snapshots. For details, see [issue description on discord (snapshot thread)](https://discord.com/channels/942378696415797298/1415495298741960735/1416349655041708143).

I debugged why this mechanism does not work and it turned out that the culprit was change from StringUtil's `substringAfter` to QuickShop's proprietary `CommonUtil.subAfter`, which used `string.lastIndexOf` instead of `string.indexOf`. I checked if other usages of `subAfter` method would break after this fix, and they will not, since they used the same method of StringUtils before.