### PR TITLE
feat/wildcard items

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -63,6 +63,7 @@ import com.ghostchu.quickshop.registry.builtin.itemexpression.SimpleItemExpressi
 import com.ghostchu.quickshop.registry.builtin.itemexpression.handlers.SimpleEnchantmentExpressionHandler;
 import com.ghostchu.quickshop.registry.builtin.itemexpression.handlers.SimpleItemReferenceExpressionHandler;
 import com.ghostchu.quickshop.registry.builtin.itemexpression.handlers.SimpleMaterialExpressionHandler;
+import com.ghostchu.quickshop.registry.builtin.itemexpression.handlers.SimpleWildcardExpressionHandler;
 import com.ghostchu.quickshop.shop.ShopLoader;
 import com.ghostchu.quickshop.shop.ShopPurger;
 import com.ghostchu.quickshop.shop.SimpleShopItemBlackList;
@@ -827,6 +828,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     itemExpressionRegistry.registerHandlerSafely(new SimpleMaterialExpressionHandler(this));
     itemExpressionRegistry.registerHandlerSafely(new SimpleEnchantmentExpressionHandler(this));
     itemExpressionRegistry.registerHandlerSafely(new SimpleItemReferenceExpressionHandler(this));
+    itemExpressionRegistry.registerHandlerSafely(new SimpleWildcardExpressionHandler(this));
   }
 
   private void loadErrorReporter() {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/registry/builtin/itemexpression/handlers/SimpleWildcardExpressionHandler.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/registry/builtin/itemexpression/handlers/SimpleWildcardExpressionHandler.java
@@ -1,0 +1,45 @@
+package com.ghostchu.quickshop.registry.builtin.itemexpression.handlers;
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.api.registry.builtin.itemexpression.ItemExpressionHandler;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Pattern;
+
+public class SimpleWildcardExpressionHandler implements ItemExpressionHandler {
+
+  private final QuickShop plugin;
+
+  public SimpleWildcardExpressionHandler(final QuickShop plugin) {
+
+    this.plugin = plugin;
+  }
+
+  @Override
+  public @NotNull Plugin getPlugin() {
+
+    return QuickShop.getInstance().getJavaPlugin();
+  }
+
+  @Override
+  public String getPrefix() {
+
+    return "*";
+  }
+
+  @Override
+  public String getInternalPrefix0() {
+
+    return getPrefix();
+  }
+
+  @Override
+  public boolean match(final ItemStack stack, final String expression) {
+
+    final String regex = expression.replace("*", ".*").replace("?", ".");
+    final Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+    return pattern.matcher(stack.getType().name()).matches();
+  }
+}

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/registry/builtin/itemexpression/handlers/SimpleWildcardExpressionHandler.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/registry/builtin/itemexpression/handlers/SimpleWildcardExpressionHandler.java
@@ -31,8 +31,7 @@ public class SimpleWildcardExpressionHandler implements ItemExpressionHandler {
 
   @Override
   public String getInternalPrefix0() {
-
-    return getPrefix();
+    return "";
   }
 
   @Override


### PR DESCRIPTION
## Add wildcard support for item blacklist patterns

Added support for wildcard patterns in the item blacklist configuration, allowing users to block entire categories of items with simple patterns.

### Features
- Wildcard patterns like `*_AXE` and `*_SPAWN_EGG` now work in blacklist configuration
- Supports `*` for any characters and `?` for single character matching
- Case-insensitive pattern matching

### Example
```yaml
blacklist:
  - "*_AXE"      # Blocks all axes
  - "*_SPAWN_EGG" # Blocks all spawn eggs
  - "DIAMOND_*"  # Blocks all diamond tools
  - "*_SWORD"    # Blocks all swords
```