### PR TITLE
Fix shop cache not invalidated on creation causing hopper protection bypass

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
@@ -112,6 +112,7 @@ public abstract class AbstractShopManager implements ShopManager {
     // Put it in the world
     // Put the shop in its location in the chunk list.
     inChunk.put(shop.getLocation(), shop);
+    shopCache.invalidate(null, shop.getLocation());
   }
 
   @Override


### PR DESCRIPTION
Hoppers placed before shop creation could steal items from the shop chest. The shop cache was not invalidated when a new shop was added, causing cached null queries to persist for up to 3 minutes.

https://github.com/QuickShop-Community/QuickShop-Hikari/blob/91a8672ab3c88d377cc7a625c351e645fc824366/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/ShopProtectionListener.java#L141-L145