### PR TITLE
Fix conditional for non-shop containers

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/PlayerListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/PlayerListener.java
@@ -21,7 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.Chest;
+import org.bukkit.block.Container;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -170,7 +170,7 @@ public class PlayerListener extends AbstractQSListener {
       }
     }
 
-    if(shop == null && b.getBlockData() instanceof Chest) {
+    if(shop == null && b.getState() instanceof Container) {
 
       return new AbstractMap.SimpleImmutableEntry<>(shop, InteractionClick.CONTAINER);
     }


### PR DESCRIPTION
To correctly evaluate containers, we need to smart-cast the BlockState to Container instead of smart-casting the BlockData to Chest. The original code attempted to smart-cast a BlockData to a BlockState Chest, which caused it to fail even for chests.