### PR TITLE
feat(bluemap): Add colored markers based on shop state

### DIFF
--- a/addon/bluemap/src/main/java/com/ghostchu/quickshop/addon/bluemap/Main.java
+++ b/addon/bluemap/src/main/java/com/ghostchu/quickshop/addon/bluemap/Main.java
@@ -90,17 +90,62 @@ public final class Main extends JavaPlugin implements Listener {
       final MarkerSet markerSet = map.getMarkerSets().computeIfAbsent("quickshop-hikari-shops", (key)->createMarkerSet());
       final String markerName = fillPlaceholders(getConfig().getString("marker-label"), shop);
       final String desc = fillPlaceholders(getConfig().getString("marker-detail"), shop);
-      final POIMarker marker = POIMarker.builder()
+      
+      final POIMarker.Builder markerBuilder = POIMarker.builder()
               .label(markerName)
               .position(shop.getLocation().getX(),
-                        shop.getLocation().getY(),
+                        shop.getLocation().getY() + 1,
                         shop.getLocation().getZ())
               .maxDistance(getConfig().getDouble("max-distance"))
-              .detail(desc)
-              .styleClasses()
-              .build();
-      markerSet.getMarkers().put("quickshop-hikari-shop" + shop.getShopId(), marker);
+              .detail(desc);
+      
+      // Use custom icon or colored circle based on config
+      if(getConfig().getBoolean("use-custom-icon", false)) {
+        final String iconPath = getConfig().getString("icon-file-location", "/assets/chest.png");
+        markerBuilder.icon(iconPath, 0, 0);
+      } else {
+        final String color = getShopColor(shop);
+        final String svgIcon = "data:image/svg+xml," + createColoredMarkerSvg(color);
+        markerBuilder.icon(svgIcon, 12, 24);  // Anchor at bottom-center of 24x24 icon
+      }
+      
+      markerSet.getMarkers().put("quickshop-hikari-shop" + shop.getShopId(), markerBuilder.build());
     }
+  }
+
+  /**
+   * Create a colored circle SVG marker
+   *
+   * @param color The fill color
+   * @return SVG string (URL encoded)
+   */
+  @NotNull
+  private String createColoredMarkerSvg(final String color) {
+
+    final String svg = "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24'>" +
+            "<circle cx='12' cy='12' r='10' fill='" + color + "' stroke='white' stroke-width='2'/>" +
+            "</svg>";
+    // URL encode for data URI
+    return svg.replace("#", "%23").replace("'", "%27");
+  }
+
+  /**
+   * Get the color for a shop based on its state
+   *
+   * @param shop The shop to get color for
+   * @return The color (CSS format)
+   */
+  @NotNull
+  private String getShopColor(final Shop shop) {
+
+    if(shop.isFrozen()) {
+      return getConfig().getString("colors.frozen", "#888888");
+    }
+    if(shop.isBuying()) {
+      return getConfig().getString("colors.buying", "#3498db");
+    }
+    // Default to selling
+    return getConfig().getString("colors.selling", "#2ecc71");
   }
 
   private String fillPlaceholders(String s, final Shop shop) {

--- a/addon/bluemap/src/main/resources/config.yml
+++ b/addon/bluemap/src/main/resources/config.yml
@@ -1,10 +1,24 @@
-config-version: 1
+config-version: 2
 # If you want the marker set/markers to display by default when opening the map.
 display-by-default: true
-#Location for the image you want as your quick-shop marker, it's defaulted to the BlueMap assets folder.
+
+# Icon settings
+# If true, uses a custom icon from icon-file-location
+# If false, uses colored circle markers based on shop state
+use-custom-icon: false
+# Location for the image you want as your quick-shop marker (only used if use-custom-icon is true)
 icon-file-location: "/assets/chest.png"
-# If you want to display the marker icon.
-display-icon: true
+
+# Marker colors for different shop states (CSS color format: hex, rgb, or color name)
+# Only used when use-custom-icon is false
+colors:
+  # Selling shops (players buy from this shop) - Green
+  selling: "#2ecc71"
+  # Buying shops (players sell to this shop) - Blue
+  buying: "#3498db"
+  # Frozen/disabled shops - Gray
+  frozen: "#888888"
+
 # Max distance of range where the user can see the marker, useful for lag reduction in frames.
 max-distance: 1000
 # This is where the name of each quick-shop marker when looking at the list (placeholders are %item%, %price%, %stock%, %owner%, %type%, %location%).


### PR DESCRIPTION
- Added colored circle SVG markers as new default option
- Green (#2ecc71) for selling shops
- Blue (#3498db) for buying shops
- Gray (#888888) for frozen/disabled shops
- Colors are configurable in config.yml
- Added use-custom-icon option to switch between custom icon and colored markers
- Kept icon-file-location for backwards compatibility
- Adjusted marker Y position for better visibility
