### PR TITLE
refactor: avoid generating debug logs outside dev mode

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/logger/Log.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/logger/Log.java
@@ -60,11 +60,11 @@ public class Log {
 
   private static void debugStdOutputs(final Record recordEntry) {
 
-    recordEntry.generate().thenAccept(log->{
-      if(Util.isDevMode()) {
-        QuickShop.getInstance().logger().info("[DEBUG] " + log);
+    if (Util.isDevMode()) {
+      recordEntry
+          .generate()
+          .thenAccept(log -> QuickShop.getInstance().logger().info("[DEBUG] " + log));
       }
-    });
   }
 
   public static void cron(@NotNull final Level level, @NotNull final String message) {


### PR DESCRIPTION
Move the generate() call inside the dev mode check to prevent
unnecessary asynchronous log generation in production.