### PR TITLE
Fix command description language key mismatch

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
@@ -678,12 +678,11 @@ public class SimpleCommandManager implements CommandManager, TabCompleter, Comma
     cmds.removeIf(commandContainer->commandContainer.getPrefix().equalsIgnoreCase(container.getPrefix()));
     cmds.removeIf(container::equals);
 
-    final String oldPrefix = container.getPrefix();
-    final String newPrefix = plugin.getCommandPrefix(oldPrefix);
+    final String newPrefix = plugin.getCommandPrefix(container.getPrefix());
     if(newPrefix != null && !newPrefix.isEmpty()) {
 
       container.setPrefix(newPrefix);
-      container.setDescription((locale)->plugin.text().of("command.description." + oldPrefix).forLocale());
+      container.setDescription((locale)->plugin.text().of("command.description." + newPrefix).forLocale());
     }
     cmds.add(container);
     cmds.sort(Comparator.comparing(CommandContainer::getPrefix));

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/SimpleCommandManager.java
@@ -682,7 +682,9 @@ public class SimpleCommandManager implements CommandManager, TabCompleter, Comma
     if(newPrefix != null && !newPrefix.isEmpty()) {
 
       container.setPrefix(newPrefix);
-      container.setDescription((locale)->plugin.text().of("command.description." + newPrefix).forLocale());
+      if(container.getDescription() == null) {
+        container.setDescription((locale)->plugin.text().of("command.description." + newPrefix).forLocale());
+      }
     }
     cmds.add(container);
     cmds.sort(Comparator.comparing(CommandContainer::getPrefix));


### PR DESCRIPTION
Use newPrefix instead of oldPrefix for command.description key lookup

https://github.com/QuickShop-Community/QuickShop-Hikari/blob/hikari/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Help.java#L68

Fixes: #2206