### PR TITLE
Fix /qs cleanghost issues with Folia scheduler

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_CleanGhost.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_CleanGhost.java
@@ -8,12 +8,14 @@ import com.ghostchu.quickshop.common.util.CommonUtil;
 import com.ghostchu.quickshop.obj.QUserImpl;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.logging.container.ShopRemoveLog;
-import com.ghostchu.quickshop.util.performance.BatchBukkitExecutor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class SubCommand_CleanGhost implements CommandHandler<CommandSender> {
 
@@ -39,50 +41,54 @@ public class SubCommand_CleanGhost implements CommandHandler<CommandSender> {
 
     plugin.text().of(sender, "cleanghost-starting").send();
     final AtomicInteger deletionCounter = new AtomicInteger(0);
-    final BatchBukkitExecutor<Shop> updateExecutor = new BatchBukkitExecutor<>();
-    updateExecutor.addTasks(plugin.getShopManager().getAllShops());
-    updateExecutor.startHandle(plugin.getJavaPlugin(), (shop)->{
-      if(shop == null) {
-        return; // WTF
-      }
-      if(shop.getOwner() == null) {
-        plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "invalid owner data").send();
-        plugin.getShopManager().deleteShop(shop);
-        deletionCounter.incrementAndGet();
-        plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
-        return;
-      }
-      if(shop.getItem().getType() == Material.AIR) {
-        plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "invalid item data").send();
-        plugin.getShopManager().deleteShop(shop);
-        deletionCounter.incrementAndGet();
-        plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
-        return;
-      }
-      if(plugin.getShopItemBlackList().isBlacklisted(shop.getItem())) {
-        plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "blacklisted item").send();
-        plugin.getShopManager().deleteShop(shop);
-        deletionCounter.incrementAndGet();
-        plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
-        return;
-      }
-      if(!shop.getLocation().isWorldLoaded()) {
-        plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "unloaded world").send();
-        plugin.getShopManager().deleteShop(shop);
-        deletionCounter.incrementAndGet();
-        plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
-        return;
-      }
-      if(!Util.canBeShop(shop.getLocation().getBlock())) {
-        plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "invalid shop block").send();
-        plugin.getShopManager().deleteShop(shop);
-        deletionCounter.incrementAndGet();
-        plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
-        return;
-      }
-    }).whenComplete((aVoid, throwable)->
-                            plugin.text().of(sender, "cleanghost-deleted", deletionCounter.get()
-                                            ).send());
+    final List<CompletableFuture<Void>> pendingTasks = new CopyOnWriteArrayList<>();
+
+    for(Shop shop : plugin.getShopManager().getAllShops()) {
+      CompletableFuture<Void> task = QuickShop.folia().getScheduler().runAtLocation(shop.getLocation(), (loc) -> {
+        if(shop == null) {
+          return; // WTF
+        }
+        if(shop.getOwner() == null) {
+          plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "invalid owner data").send();
+          plugin.getShopManager().deleteShop(shop);
+          deletionCounter.incrementAndGet();
+          plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
+          return;
+        }
+        if(shop.getItem().getType() == Material.AIR) {
+          plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "invalid item data").send();
+          plugin.getShopManager().deleteShop(shop);
+          deletionCounter.incrementAndGet();
+          plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
+          return;
+        }
+        if(plugin.getShopItemBlackList().isBlacklisted(shop.getItem())) {
+          plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "blacklisted item").send();
+          plugin.getShopManager().deleteShop(shop);
+          deletionCounter.incrementAndGet();
+          plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
+          return;
+        }
+        if(!shop.getLocation().isWorldLoaded()) {
+          plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "unloaded world").send();
+          plugin.getShopManager().deleteShop(shop);
+          deletionCounter.incrementAndGet();
+          plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
+          return;
+        }
+        if(!Util.canBeShop(shop.getLocation().getBlock())) {
+          plugin.text().of(sender, "cleanghost-deleting", shop.getShopId(), "invalid shop block").send();
+          plugin.getShopManager().deleteShop(shop);
+          deletionCounter.incrementAndGet();
+          plugin.logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "SYSTEM", false), "/quickshop cleanghost command", shop.saveToInfoStorage()));
+          return;
+        }
+      });
+      pendingTasks.add(task);
+    }
+
+    CompletableFuture.allOf(pendingTasks.toArray(new CompletableFuture[0]))
+            .whenComplete((v, t) -> plugin.text().of(sender, "cleanghost-deleted", deletionCounter.get()).send());
 
   }
 


### PR DESCRIPTION
This pull request refactors the ghost shop cleaning command to improve concurrency and reliability. The main change is replacing the use of `BatchBukkitExecutor` with a more modern and thread-safe approach using `CompletableFuture` and `CopyOnWriteArrayList`, which better supports concurrent operations and integrates with the Folia scheduler.

**Concurrency and task management improvements:**

* Replaced the `BatchBukkitExecutor` for shop deletion tasks with a `CompletableFuture`-based approach, using `CopyOnWriteArrayList` to collect all asynchronous deletion tasks and `CompletableFuture.allOf` to wait for their completion. This provides better concurrency control and thread safety. [[1]](diffhunk://#diff-ef54ae4eb6618ea59c92defdd93f635290442747721deb753f19b28be8ab93f8L11-L17) [[2]](diffhunk://#diff-ef54ae4eb6618ea59c92defdd93f635290442747721deb753f19b28be8ab93f8L42-R47)
* Integrated the Folia scheduler by running each shop deletion task at the shop's location, ensuring compatibility with Folia's region threading model.
* Updated the completion logic to send a summary message to the user only after all deletion tasks are finished, ensuring accurate feedback.