### PR TITLE
Fix WorldEdit support in folia

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/hook/fworldedit/ShopProcessor.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/hook/fworldedit/ShopProcessor.java
@@ -80,7 +80,7 @@ public class ShopProcessor implements IBatchProcessor {
 
         final Shop shop = QuickShop.getInstance().getShopManager().getShop(location, true); // Because WorldEdit can only remove half of shop, so we can keep another half as shop if it is doublechest shop.
         if(shop != null) {
-          Util.mainThreadRun(()->{
+          Util.regionThread(shop.getLocation(), () -> {
             QuickShop.getInstance().logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "WorldEdit", false), "WorldEdit", shop.saveToInfoStorage()));
             QuickShop.getInstance().getShopManager().deleteShop(shop);
           });

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/hook/worldedit/WorldEditBlockListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/hook/worldedit/WorldEditBlockListener.java
@@ -54,7 +54,7 @@ public class WorldEditBlockListener extends AbstractDelegateExtent {
 
         final Shop shop = QuickShop.getInstance().getShopManager().getShop(location, true); // Because WorldEdit can only remove half of shop, so we can keep another half as shop if it is doublechest shop.
         if(shop != null) {
-          Util.mainThreadRun(()->{
+          Util.regionThread(shop.getLocation(), () -> {
             QuickShop.getInstance().logEvent(new ShopRemoveLog(QUserImpl.createFullFilled(CommonUtil.getNilUniqueId(), "WorldEdit", false), "WorldEdit", shop.saveToInfoStorage()));
             QuickShop.getInstance().getShopManager().deleteShop(shop);
           });


### PR DESCRIPTION
fix
```
[21:38:47] [Folia Region Scheduler Thread #1/INFO]: Daylight_Yuan issued server command: //set 0
[21:38:47] [Folia Region Scheduler Thread #0/ERROR]: [ca.spottedleaf.moonrise.common.util.TickThread] Thread failed main thread check: Cannot read world asynchronously, context=[thread=Folia Region Scheduler Thread #0,class=io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner,region={null}], world=world, block_pos=BlockPos{x=15, y=70, z=5}
java.lang.Throwable
	at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:61) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at org.bukkit.craftbukkit.block.CraftBlock.getNMS(CraftBlock.java:80) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(CraftBlockStates.java:197) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at org.bukkit.craftbukkit.block.CraftBlock.getState(CraftBlock.java:356) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.shop.ContainerShop.getSigns(ContainerShop.java:887) ~[?:?]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.shop.SimpleShopManager.deleteShop(SimpleShopManager.java:1300) ~[?:?]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.hook.worldedit.WorldEditBlockListener.lambda$setBlock$0(WorldEditBlockListener.java:59) ~[?:?]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.shade.com.tcoded.impl.FoliaImplementation.lambda$runLater$2(FoliaImplementation.java:118) ~[?:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:178) ~[folia-1.21.11.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:36) ~[folia-1.21.11.jar:?]
	at io.papermc.paper.threadedregions.RegionizedServer.globalTick(RegionizedServer.java:340) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at io.papermc.paper.threadedregions.RegionizedServer$GlobalTickTickHandle.tickRegion(RegionizedServer.java:184) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:481) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool$TickThreadRunner.run(EDFSchedulerThreadPool.java:526) ~[concurrentutil-0.0.8.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1570) ~[?:?]
[21:38:47] [Folia Region Scheduler Thread #0/WARN]: [QuickShop-Hikari] Global task for QuickShop-Hikari v6.2.0.11 generated an exception
java.lang.IllegalStateException: Thread failed main thread check: Cannot read world asynchronously, context=[thread=Folia Region Scheduler Thread #0,class=io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner,region={null}], world=world, block_pos=BlockPos{x=15, y=70, z=5}
	at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:62) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at org.bukkit.craftbukkit.block.CraftBlock.getNMS(CraftBlock.java:80) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(CraftBlockStates.java:197) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at org.bukkit.craftbukkit.block.CraftBlock.getState(CraftBlock.java:356) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.shop.ContainerShop.getSigns(ContainerShop.java:887) ~[?:?]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.shop.SimpleShopManager.deleteShop(SimpleShopManager.java:1300) ~[?:?]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.hook.worldedit.WorldEditBlockListener.lambda$setBlock$0(WorldEditBlockListener.java:59) ~[?:?]
	at QuickShop-Hikari-6.2.0.11 (1).jar//com.ghostchu.quickshop.shade.com.tcoded.impl.FoliaImplementation.lambda$runLater$2(FoliaImplementation.java:118) ~[?:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:178) ~[folia-1.21.11.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:36) ~[folia-1.21.11.jar:?]
	at io.papermc.paper.threadedregions.RegionizedServer.globalTick(RegionizedServer.java:340) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at io.papermc.paper.threadedregions.RegionizedServer$GlobalTickTickHandle.tickRegion(RegionizedServer.java:184) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:481) ~[folia-1.21.11.jar:1.21.11-11-e112b00]
	at ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool$TickThreadRunner.run(EDFSchedulerThreadPool.java:526) ~[concurrentutil-0.0.8.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1570) ~[?:?]
```