### PR TITLE
Enforce maximum-digits-in-price on shop price updates

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Price.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Price.java
@@ -8,6 +8,7 @@ import com.ghostchu.quickshop.obj.QUserImpl;
 import com.ghostchu.quickshop.util.ShopUtil;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.logger.Log;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,6 +44,15 @@ public class SubCommand_Price implements CommandHandler<Player> {
       Log.debug("Price sub command had issue with price parameter.");
       plugin.text().of(sender, "not-a-number", parser.getArgs().getFirst()).send();
       return;
+    }
+
+    final int maximumDigitsInPrice = plugin.getConfig().getInt("maximum-digits-in-price", -1);
+    if(maximumDigitsInPrice != -1) {
+      final int inputScale = Math.max(price.stripTrailingZeros().scale(), 0);
+      if(inputScale > maximumDigitsInPrice) {
+        plugin.text().of(sender, "digits-reach-the-limit", Component.text(maximumDigitsInPrice)).send();
+        return;
+      }
     }
 
     final double priceDouble = price.doubleValue();

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Price.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Price.java
@@ -46,7 +46,7 @@ public class SubCommand_Price implements CommandHandler<Player> {
       return;
     }
 
-    final int maximumDigitsInPrice = plugin.getConfig().getInt("maximum-digits-in-price", -1);
+    final int maximumDigitsInPrice = plugin.getConfig().getInt("shop.maximum-digits-in-price", -1);
     if(maximumDigitsInPrice != -1) {
       final int inputScale = Math.max(price.stripTrailingZeros().scale(), 0);
       if(inputScale > maximumDigitsInPrice) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -184,7 +184,7 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
     this.priceLimiter = new SimplePriceLimiter(plugin);
     this.useOldCanBuildAlgorithm = plugin.getConfig().getBoolean("limits.old-algorithm");
     this.autoSign = plugin.getConfig().getBoolean("shop.auto-sign");
-    this.maximumDigitsLimit = plugin.getConfig().getInt("maximum-digits-in-price", -1);
+    this.maximumDigitsLimit = plugin.getConfig().getInt("shop.maximum-digits-in-price", -1);
     this.allowNoSpaceForSign = plugin.getConfig().getBoolean("shop.allow-shop-without-space-for-sign");
     this.useDecFormat = plugin.getConfig().getBoolean("use-decimal-format");
     this.shopCreateCost = plugin.getConfig().getDouble("shop.cost");

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -141,7 +141,7 @@ public class ShopUtil {
       return;
     }
 
-    final int maximumDigitsInPrice = plugin.getConfig().getInt("maximum-digits-in-price", -1);
+    final int maximumDigitsInPrice = plugin.getConfig().getInt("shop.maximum-digits-in-price", -1);
     if(maximumDigitsInPrice != -1) {
       final int inputScale = Math.max(BigDecimal.valueOf(price).stripTrailingZeros().scale(), 0);
       if(inputScale > maximumDigitsInPrice) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/ShopUtil.java
@@ -141,6 +141,15 @@ public class ShopUtil {
       return;
     }
 
+    final int maximumDigitsInPrice = plugin.getConfig().getInt("maximum-digits-in-price", -1);
+    if(maximumDigitsInPrice != -1) {
+      final int inputScale = Math.max(BigDecimal.valueOf(price).stripTrailingZeros().scale(), 0);
+      if(inputScale > maximumDigitsInPrice) {
+        plugin.text().of(user, "digits-reach-the-limit", Component.text(maximumDigitsInPrice)).send();
+        return;
+      }
+    }
+
     final PriceLimiterCheckResult checkResult = limiter.check(user, shop.getItem(), plugin.getCurrency(), price);
 
     switch(checkResult.getStatus()) {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -501,7 +501,7 @@ public class Util {
 
         if(exponent > 0) {
 
-          final int digits = QuickShop.getInstance().getConfig().getInt("maximum-digits-in-price", -1);
+          final int digits = QuickShop.getInstance().getConfig().getInt("shop.maximum-digits-in-price", -1);
           final BigDecimal value = baseValue.multiply(BigDecimal.TEN.pow(exponent));
           if(digits == -1) {
             return value;


### PR DESCRIPTION
- Add command-level validation in /qs price so inputs with too many decimal places are rejected before processing.

- Add shared validation in ShopUtil.setPrice so GUI and other price update paths also honor maximum-digits-in-price.

- Reuse the existing digits-reach-the-limit message when precision exceeds the configured limit.