### PR TITLE
Fix Folia thread violations in /qs info stock stats

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Info.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Info.java
@@ -12,7 +12,11 @@ import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SubCommand_Info implements CommandHandler<CommandSender> {
 
@@ -31,6 +35,8 @@ public class SubCommand_Info implements CommandHandler<CommandSender> {
     int chunks = 0;
     int worlds = 0;
     int nostock = 0;
+    final boolean folia = QuickShop.folia().isFolia();
+    final List<Shop> outOfStockCheckQueue = folia? new ArrayList<>() : null;
 
     for(final Map<ShopChunk, Map<Location, Shop>> inWorld :
             plugin.getShopManager().getShops().values()) {
@@ -44,12 +50,51 @@ public class SubCommand_Info implements CommandHandler<CommandSender> {
           } else if(shop.isSelling()) {
             selling++;
           }
-          if(shop.isSelling() && shop.isLoaded() && shop.getRemainingStock() == 0) {
-            nostock++;
+          if(shop.isSelling() && shop.isLoaded()) {
+            if(folia) {
+              outOfStockCheckQueue.add(shop);
+            } else if(shop.getRemainingStock() == 0) {
+              nostock++;
+            }
           }
         }
       }
     }
+
+    if(!folia) {
+      sendStats(sender, buying, selling, chunks, worlds, nostock);
+      return;
+    }
+
+    if(outOfStockCheckQueue.isEmpty()) {
+      sendStats(sender, buying, selling, chunks, worlds, 0);
+      return;
+    }
+
+    final AtomicInteger noStockCounter = new AtomicInteger(0);
+    final List<CompletableFuture<Void>> futures = new ArrayList<>(outOfStockCheckQueue.size());
+    for(final Shop shop : outOfStockCheckQueue) {
+      final CompletableFuture<Void> future = QuickShop.folia().getScheduler().runAtLocation(shop.getLocation(), task -> {
+        try {
+          if(shop.getRemainingStock() == 0) {
+            noStockCounter.incrementAndGet();
+          }
+        } catch(final Throwable ignored) {
+        }
+      });
+      futures.add(future);
+    }
+
+    final int buyingFinal = buying;
+    final int sellingFinal = selling;
+    final int chunksFinal = chunks;
+    final int worldsFinal = worlds;
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            .whenComplete((unused, throwable)->QuickShop.folia().getScheduler().runLater(()->
+                    sendStats(sender, buyingFinal, sellingFinal, chunksFinal, worldsFinal, noStockCounter.get()), 1));
+  }
+
+  private void sendStats(@NotNull final CommandSender sender, final int buying, final int selling, final int chunks, final int worlds, final int nostock) {
 
     MsgUtil.sendDirectMessage(sender, Component.text("QuickShop Statistics...").color(NamedTextColor.GOLD));
     MsgUtil.sendDirectMessage(sender, Component.text("Server UniqueId: " + plugin.getServerUniqueID()).color(NamedTextColor.GREEN));


### PR DESCRIPTION
Root cause: SubCommand_Info called shop.getRemainingStock() while iterating all shops from one command execution context, which can access world blocks outside the owning region on Folia.

Fix: keep the same stats output but on Folia run each stock check via scheduler.runAtLocation(shop.getLocation(), ...) and aggregate results with CompletableFuture.allOf before sending the final message.

Non-Folia behavior remains synchronous and unchanged.

Error prior to change:
```
[18:37:32] [Folia Region Scheduler Thread #5/ERROR]: [ca.spottedleaf.moonrise.common.util.TickThread] Thread failed main thread check: Cannot read world asynchronously, context=[thread=Folia Region Scheduler Thread #5,class=io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner,region={center=[-1603, -907],world=world}], world=world, block_pos=BlockPos{x=9124, y=64, z=-13071} java.lang.Throwable at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:61) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at org.bukkit.craftbukkit.block.CraftBlock.getNMS(CraftBlock.java:80) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(CraftBlockStates.java:197) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at org.bukkit.craftbukkit.block.CraftBlock.getState(CraftBlock.java:356) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapperManager.fromLocation(BukkitInventoryWrapperManager.java:69) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapperManager.locateNew(BukkitInventoryWrapperManager.java:44) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.inventory.BukkitInventoryWrapperManager.locate(BukkitInventoryWrapperManager.java:30) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.ContainerShop.locateInventory(ContainerShop.java:1831) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.ContainerShop.getInventory(ContainerShop.java:480) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.ContainerShop.getRemainingStock(ContainerShop.java:693) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.subcommand.SubCommand_Info.onCommand(SubCommand_Info.java:47) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.api.command.CommandHandler.onCommand_Internal(CommandHandler.java:87) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.SimpleCommandManager.onCommand(SimpleCommandManager.java:546) ~[?:?] at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.QuickShopCommand.execute(QuickShopCommand.java:23) ~[?:?] at io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:83) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.3.10.jar:?] at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:30) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:104) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:469) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.commands.Commands.performCommand(Commands.java:374) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.commands.Commands.performCommand(Commands.java:362) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.server.network.ServerGamePacketListenerImpl.performUnsignedChatCommand(ServerGamePacketListenerImpl.java:2419) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$13(ServerGamePacketListenerImpl.java:2392) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$tryHandleChat$16(ServerGamePacketListenerImpl.java:2551) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at io.papermc.paper.threadedregions.EntityScheduler.executeTick(EntityScheduler.java:243) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1732) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:429) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:485) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:481) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd] at ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool$TickThreadRunner.run(EDFSchedulerThreadPool.java:526) ~[concurrentutil-0.0.8.jar:?] at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```