### PR TITLE
Config-Driven Data Component Matcher (1.21+)

### DIFF
--- a/.changelog/6.3.0.0.md
+++ b/.changelog/6.3.0.0.md
@@ -7,6 +7,36 @@
 
 ## Major Changes
 
+### Config-Driven Data Component Matcher (1.21+)
+
+This uses worker-type: 3.
+
+### Changes
+
+* Updated matcher to store and compare DataComponentType.Valued<?> entries.
+* Resolved registry entries safely using the Paper data component registry.
+* Implemented whitelist-based matching: only components explicitly enabled in matcher.components are compared.
+* Merged previous meta toggles into components using uppercase group keys.
+* Explicitly excluded CUSTOM_DATA from comparison to prevent ViaVersion protocol markers from causing mismatches.
+
+### Behavior
+
+Matching now:
+
+1. Handles null safety.
+2. Optionally checks material.
+3. Optionally checks stack amount.
+4. Iterates only over enabled component types.
+5. Returns false immediately on the first mismatch.
+6. Returns true if all enabled components match.
+
+### Config Structure
+
+All comparisons are configured under matcher.components. Keys can be:
+
+* Direct DataComponentTypeKeys fields (e.g., DAMAGE, LORE, ENCHANTMENTS).
+* Group keys that expand internally (e.g., BOOKS, SHULKER_BOX, FIREWORK).
+
 ### Updater System Refactor + Modrinth Support
 
 #### Added

--- a/addon/betonquest/pom.xml
+++ b/addon/betonquest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/addon/bluemap/pom.xml
+++ b/addon/bluemap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discordsrv/pom.xml
+++ b/addon/discordsrv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/discount/pom.xml
+++ b/addon/discount/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/displaycontrol/pom.xml
+++ b/addon/displaycontrol/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/dynmap/pom.xml
+++ b/addon/dynmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/limited/pom.xml
+++ b/addon/limited/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/list/pom.xml
+++ b/addon/list/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/pl3xmap/pom.xml
+++ b/addon/pl3xmap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/plan/pom.xml
+++ b/addon/plan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.ghostchu</groupId>
             <artifactId>quickshop-platform-interface</artifactId>
-            <version>6.3.0.0-SNAPSHOT-4</version>
+            <version>6.3.0.0-SNAPSHOT-5</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/addon/quests/pom.xml
+++ b/addon/quests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/addon/reremake-migrator/pom.xml
+++ b/addon/reremake-migrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/shopitemonly/pom.xml
+++ b/addon/shopitemonly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/addon/squaremap/pom.xml
+++ b/addon/squaremap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.addon</groupId>

--- a/compatibility/advancedregionmarket/pom.xml
+++ b/compatibility/advancedregionmarket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/angelchest/pom.xml
+++ b/compatibility/angelchest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bentobox/pom.xml
+++ b/compatibility/bentobox/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord-geyser/pom.xml
+++ b/compatibility/bungeecord-geyser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/bungeecord/pom.xml
+++ b/compatibility/bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/chestprotect/pom.xml
+++ b/compatibility/chestprotect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/clearlag/pom.xml
+++ b/compatibility/clearlag/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/common/pom.xml
+++ b/compatibility/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/dominion/pom.xml
+++ b/compatibility/dominion/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ecoenchants/pom.xml
+++ b/compatibility/ecoenchants/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/elitemobs/pom.xml
+++ b/compatibility/elitemobs/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/fabledskyblock/pom.xml
+++ b/compatibility/fabledskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/griefprevention/pom.xml
+++ b/compatibility/griefprevention/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/husktowns/pom.xml
+++ b/compatibility/husktowns/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/iridiumskyblock/pom.xml
+++ b/compatibility/iridiumskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/itemsadder/pom.xml
+++ b/compatibility/itemsadder/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/lands/pom.xml
+++ b/compatibility/lands/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/matcherplus/pom.xml
+++ b/compatibility/matcherplus/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/openinv/pom.xml
+++ b/compatibility/openinv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/plotsquared/pom.xml
+++ b/compatibility/plotsquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/reforges/pom.xml
+++ b/compatibility/reforges/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/residence/pom.xml
+++ b/compatibility/residence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/simpleclaimsystem/pom.xml
+++ b/compatibility/simpleclaimsystem/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/slimefun/pom.xml
+++ b/compatibility/slimefun/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/superiorskyblock/pom.xml
+++ b/compatibility/superiorskyblock/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/towny/pom.xml
+++ b/compatibility/towny/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/ultimateclaims/pom.xml
+++ b/compatibility/ultimateclaims/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/velocity/pom.xml
+++ b/compatibility/velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/voidchest/pom.xml
+++ b/compatibility/voidchest/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/compatibility/worldguard/pom.xml
+++ b/compatibility/worldguard/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>com.ghostchu.quickshop.compatibility</groupId>

--- a/platform/quickshop-platform-interface/pom.xml
+++ b/platform/quickshop-platform-interface/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/platform/quickshop-platform-paper/pom.xml
+++ b/platform/quickshop-platform-paper/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu</groupId>
     <artifactId>quickshop-hikari</artifactId>
-    <version>6.3.0.0-SNAPSHOT-4</version>
+    <version>6.3.0.0-SNAPSHOT-5</version>
     <packaging>pom</packaging>
     <name>quickshop-hikari</name>
     <description>Another QuickShop fork</description>

--- a/quickshop-api/pom.xml
+++ b/quickshop-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quickshop-bukkit/pom.xml
+++ b/quickshop-bukkit/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ghostchu</groupId>
         <artifactId>quickshop-hikari</artifactId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
     </parent>
 
     <properties>

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -95,6 +95,7 @@ import com.ghostchu.quickshop.util.envcheck.ResultContainer;
 import com.ghostchu.quickshop.util.envcheck.ResultReport;
 import com.ghostchu.quickshop.util.logger.Log;
 import com.ghostchu.quickshop.util.matcher.item.BukkitItemMatcherImpl;
+import com.ghostchu.quickshop.util.matcher.item.ModernCustomMatcher;
 import com.ghostchu.quickshop.util.matcher.item.QuickShopItemMatcherImpl;
 import com.ghostchu.quickshop.util.matcher.item.TNEItemMatcherImpl;
 import com.ghostchu.quickshop.util.metric.MetricManager;
@@ -885,7 +886,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
   private void loadItemMatcher() {
 
     final ItemMatcher defItemMatcher = switch(getConfig().getInt("matcher.work-type")) {
-      case 3 -> new TNEItemMatcherImpl(this);
+      case 3 -> new ModernCustomMatcher(this);
       case 1 -> new BukkitItemMatcherImpl(this);
       case 0 -> new QuickShopItemMatcherImpl(this);
       default ->

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/matcher/item/ModernCustomMatcher.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/matcher/item/ModernCustomMatcher.java
@@ -1,0 +1,312 @@
+package com.ghostchu.quickshop.util.matcher.item;
+
+/*
+ * QuickShop-Hikari
+ * Copyright (C) 2026 Daniel "creatorfromhell" Vidmar
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import com.ghostchu.quickshop.QuickShop;
+import com.ghostchu.quickshop.api.shop.ItemMatcher;
+import com.ghostchu.simplereloadlib.ReloadResult;
+import com.ghostchu.simplereloadlib.ReloadStatus;
+import com.ghostchu.simplereloadlib.Reloadable;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
+import io.papermc.paper.datacomponent.DataComponentType;
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * ModernCustomMatcher
+ *
+ * Config-driven ItemStack matcher using Paper's Data Component API.
+ *
+ * Whitelist-based:
+ * - Only enabled keys under matcher.components.* are compared.
+ * - Keys can be either:
+ *   1) A direct DataComponentTypeKeys field (e.g. DAMAGE, LORE, ENCHANTMENTS)
+ *   2) A group key that expands into multiple component keys (e.g. BOOKS, SHULKER_BOX)
+ *
+ * ViaVersion compatibility:
+ * - CUSTOM_DATA is NEVER compared (ViaVersion writes VV|Protocol tags into minecraft:custom_data).
+ *
+ * @author creatorfromhell
+ * @since 6.3.0.0
+ */
+public class ModernCustomMatcher implements ItemMatcher, Reloadable {
+
+  private final QuickShop plugin;
+
+  /**
+   * If true, stack amount is ignored.
+   */
+  private boolean ignoreCount;
+
+  /**
+   * If true, ItemStack#getType must match.
+   */
+  private boolean checkMaterial;
+
+  /**
+   * Cached list of valued component types that must match (whitelist).
+   * Built on init/reload from config.
+   */
+  private volatile List<DataComponentType.Valued<?>> compareTypes = List.of();
+
+  public ModernCustomMatcher(@NotNull final QuickShop plugin) {
+
+    this.plugin = plugin;
+    plugin.getReloadManager().register(this);
+    init();
+  }
+
+  private void init() {
+
+    this.ignoreCount = plugin.getConfig().getBoolean("matcher.ignore-count", true);
+    this.checkMaterial = plugin.getConfig().getBoolean("matcher.check-material", true);
+
+    this.compareTypes = Collections.unmodifiableList(loadCompareTypes());
+  }
+
+  @Override
+  public ReloadResult reloadModule() {
+
+    init();
+    return ReloadResult.builder().status(ReloadStatus.SUCCESS).build();
+  }
+
+  @Override
+  public @NotNull String getName() {
+
+    return "modern-matcher";
+  }
+
+  @Override
+  public @NotNull Plugin getPlugin() {
+
+    return plugin.getJavaPlugin();
+  }
+
+  @Override
+  public boolean matches(@Nullable final ItemStack original, @Nullable final ItemStack tester) {
+
+    //System.out.println("ModernCustomMatcher.matches");
+
+    if(original == null && tester == null) {
+      return true;
+    }
+
+    if(original == null || tester == null) {
+      return false;
+    }
+
+    //System.out.println("ModernCustomMatcher.matches: checking material");
+
+    // Fast-fail: material mismatch (recommended)
+    if(checkMaterial && original.getType() != tester.getType()) {
+      return false;
+    }
+
+    //System.out.println("ModernCustomMatcher.matches: checking amount");
+    // Optional: amount mismatch
+    if(!ignoreCount && original.getAmount() != tester.getAmount()) {
+      return false;
+    }
+
+    // Whitelist compare: only configured component types
+    for(final DataComponentType.Valued<?> type : compareTypes) {
+
+      //System.out.println("ModernCustomMatcher.matches: checking type: " + type.key().asString());
+      final Object a = original.getData(type);
+      final Object b = tester.getData(type);
+
+      if(!Objects.equals(a, b)) {
+        //System.out.println("ModernCustomMatcher.matches: type mismatch: " + type.key().asString());
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Loads and resolves the whitelist valued component types from config.
+   *
+   * Config:
+   * matcher.components:
+   *   DAMAGE: true
+   *   LORE: true
+   *   BOOKS: true
+   *   SHULKER_BOX: false
+   */
+  private List<DataComponentType.Valued<?>> loadCompareTypes() {
+
+    final var registry = RegistryAccess.registryAccess().getRegistry(RegistryKey.DATA_COMPONENT_TYPE);
+
+    final LinkedHashSet<DataComponentType.Valued<?>> out = new LinkedHashSet<>();
+
+    final Section section = plugin.getConfig().getSection("matcher.components");
+    if(section == null) {
+      return List.of();
+    }
+
+    for(final String rawKey : section.getRoutesAsStrings(false)) {
+
+      //System.out.println("ModernCustomMatcher.loadCompareTypes: checking key: " + rawKey);
+
+      if(!section.getBoolean(rawKey, false)) {
+        //System.out.println("ModernCustomMatcher.loadCompareTypes: key disabled: " + rawKey);
+        continue;
+      }
+
+      final String key = rawKey.toLowerCase(Locale.ROOT);
+
+      //Try to convert the naming directly to the DataComponentType key
+      final DataComponentType.Valued<?> valued = resolveTypeKeyFromDataComponentTypeKeys(key);
+      if(valued != null) {
+
+        //System.out.println("ModernCustomMatcher.loadCompareTypes: adding type: " + key);
+        out.add(valued);
+        continue;
+      }
+      //System.out.println("ModernCustomMatcher.loadCompareTypes: key not found: " + key);
+
+      //might be a grouped type, which includes multiples.
+      expandGroup(out, registry, key);
+    }
+
+    return new ArrayList<>(out);
+  }
+
+  private void expandGroup(final Set<DataComponentType.Valued<?>> out,
+                           final Registry<DataComponentType> registry,
+                           final String groupName) {
+
+    switch(groupName) {
+
+      // Book content (editable + written)
+      case "books" -> add(out, registry,
+                          "WRITABLE_BOOK_CONTENT",
+                          "WRITTEN_BOOK_CONTENT"
+                         );
+
+      // Banner patterns
+      case "banner" -> add(out, registry,
+                           "BANNER_PATTERNS"
+                          );
+
+      // Skull owner profile/texture
+      case "skull" -> add(out, registry,
+                          "PROFILE"
+                         );
+
+      // Firework rocket + star
+      case "firework" -> add(out, registry,
+                             "FIREWORKS",
+                             "FIREWORK_EXPLOSION"
+                            );
+
+      // Map metadata
+      case "map" -> add(out, registry,
+                        "MAP_ID",
+                        "MAP_DECORATIONS",
+                        "MAP_POST_PROCESSING"
+                       );
+
+      // Leather armor dyed color
+      case "leather_armor" -> add(out, registry,
+                                  "DYED_COLOR"
+                                 );
+
+      // Fish bucket entity data
+      case "fish_bucket" -> add(out, registry,
+                                "BUCKET_ENTITY_DATA"
+                               );
+
+      // Suspicious stew effects
+      case "suspicious_stew" -> add(out, registry,
+                                    "SUSPICIOUS_STEW_EFFECTS"
+                                   );
+
+      // Shulker container contents (+ loot table marker if present)
+      case "shulker_box" -> add(out, registry,
+                                "CONTAINER",
+                                "CONTAINER_LOOT"
+                               );
+
+      // Bundle contents
+      case "bundle" -> add(out, registry,
+                           "BUNDLE_CONTENTS"
+                          );
+
+      default -> {
+      }
+    }
+  }
+
+  private void add(final Set<DataComponentType.Valued<?>> out,
+                   final Registry<DataComponentType> registry,
+                   final String... keyNames) {
+
+    for(final String rawKey : keyNames) {
+
+      final String key = rawKey.toLowerCase(Locale.ROOT);
+
+      final DataComponentType.Valued<?> valued = resolveTypeKeyFromDataComponentTypeKeys(key);
+      if(valued == null) {
+
+        plugin.logger().warn("[ModernCustomMatcher] Unknown DataComponentTypeKeys field: " + key);
+        continue;
+      }
+
+      if(valued != null) {
+        //System.out.println("ModernCustomMatcher.loadCompareTypes: adding type: " + key);
+        out.add(valued);
+      }
+    }
+  }
+
+  /**
+   * Reflectively resolves a DataComponentTypeKeys.<FIELD> to a DataComponentType.Valued.
+   *
+   * This avoids hard depending on every constant at compile-time and lets config drive selection.
+   */
+  @SuppressWarnings("unchecked")
+  private static @Nullable DataComponentType.Valued resolveTypeKeyFromDataComponentTypeKeys(final String name) {
+
+    try {
+      //System.out.println("ModernCustomMatcher.resolveTypeKeyFromDataComponentTypeKeys: " + name);
+      final DataComponentType.Valued dataType = (DataComponentType.Valued)Registry.DATA_COMPONENT_TYPE.get(NamespacedKey.minecraft(name.toLowerCase(Locale.ROOT)));
+      return dataType;
+    } catch(final ClassCastException ex) {
+      //System.out.println("ModernCustomMatcher.resolveTypeKeyFromDataComponentTypeKeys: " + name + " is not a valued type!");
+      return null;
+    }
+  }
+}

--- a/quickshop-bukkit/src/main/resources/config.yml
+++ b/quickshop-bukkit/src/main/resources/config.yml
@@ -1,7 +1,7 @@
 # QuickShop-Hikari Plugin Configuration
 
 #Do not touch this if you don't know what you're doing!
-config-version: 1038
+config-version: 1039
 
 #Set the default language code the plugin should use
 #Set it to default will use your system language.
@@ -665,53 +665,115 @@ effect:
     #Should we play sound while player clicking shop container/sign?
     onclick: true
 #Item matcher.
-#Do not touch it if you don't know what you're doing!
+#don't touch if you don't know what you're doing.
 matcher:
+
   #Matcher type
   #0= QuickShop item matcher with configurable options below.
   #1= Bukkit item matcher, can be more accurate.
   #2= Stricter Bukkit matcher, equals method.
+  #3 = modern matcher
   work-type: 1
-  #For Item (Only works under QuickShop ItemMatcher)
-  item:
-    #Should the Plugin check the item damage?
-    damage: true
-    #Should the Plugin check the item repair cost?
-    repaircost: false
-    #Should the Plugin check the item display name?
-    displayname: true
-    #Should the Plugin check the item lores?
-    lores: true
-    #Should the Plugin check the item enchs?
-    enchs: true
-    #Should the Plugin check the item potions?
-    potions: true
-    #Should the Plugin check the item attributes?
-    attributes: true
-    #Should the Plugin check the item itemflags?
-    itemflags: true
-    #Should the Plugin check the item custommodeldata?
-    custommodeldata: true
-    #Should the Plugin check the item bookmetas?
-    books: true
-    #Should the Plugin check the banner meta?
-    banner: true
-    #Should the Plugin check the skull meta?
-    skull: true
-    #Should the Plugin check the firework meta?
-    firework: true
-    #Should the Plugin check the map meta?
-    map: true
-    #Should the Plugin check the leather armor meta?
-    leatherArmor: true
-    #Should the Plugin check the fishBucket meta?
-    fishBucket: true
-    #Should the Plugin check the suspiciousStew meta?
-    suspiciousStew: true
-    #Should the Plugin check the shulkerBox contents?
-    shulkerBox: true
-    #Should the Plugin check the bundle contents?
-    bundle: true
+
+  # If true, stack amount will NOT be considered during matching.
+  # Recommended for shop matching.
+  ignore-count: true
+
+  # If true, material (ItemStack#getType) must match.
+  # Strongly recommended.
+  check-material: true
+
+  # Compare ONLY what is enabled below.
+  # - DIRECT keys map 1:1 to DataComponentTypeKeys.<KEY>
+  # - GROUP keys expand to multiple underlying component keys
+  components:
+
+    # ------------------------------
+    # DIRECT COMPONENT KEYS
+    # ------------------------------
+
+    #Should the Plugin check the item damage (durability)?
+    DAMAGE: true
+
+    #Should the Plugin check the anvil repair cost?
+    REPAIR_COST: false
+
+    #Should the Plugin check the custom display name?
+    CUSTOM_NAME: true
+
+    #Should the Plugin check the item name override?
+    ITEM_NAME: false
+
+    #Should the Plugin check lore?
+    LORE: true
+
+    #Should the Plugin check CustomModelData?
+    CUSTOM_MODEL_DATA: true
+
+    #Should the Plugin check enchantments?
+    ENCHANTMENTS: true
+
+    #Should the Plugin check stored enchantments (enchanted books)?
+    STORED_ENCHANTMENTS: true
+
+    #Should the Plugin check attribute modifiers?
+    ATTRIBUTE_MODIFIERS: true
+
+    #Should the Plugin check unbreakable flag?
+    UNBREAKABLE: true
+
+    #Should the Plugin check armor trim?
+    TRIM: true
+
+    #Should the Plugin check dyed color?
+    DYED_COLOR: true
+
+    #Should the Plugin check tooltip hide flags?
+    HIDE_ADDITIONAL_TOOLTIP: true
+
+    #Should the Plugin check enchantment glint override?
+    ENCHANTMENT_GLINT_OVERRIDE: true
+
+    #Should the Plugin check potion contents?
+    POTION_CONTENTS: true
+
+    #Should the Plugin check potion duration scaling?
+    POTION_DURATION_SCALE: true
+
+    # ------------------------------
+    # GROUP COMPONENT TOGGLES
+    # (Expand into multiple component keys)
+    # ------------------------------
+
+    #Should the Plugin check book content (written & writable)?
+    BOOKS: true
+
+    #Should the Plugin check banner patterns?
+    BANNER: true
+
+    #Should the Plugin check skull profile/texture?
+    SKULL: true
+
+    #Should the Plugin check firework meta (rockets + stars)?
+    FIREWORK: true
+
+    #Should the Plugin check map metadata?
+    MAP: true
+
+    #Should the Plugin check leather armor dye color?
+    LEATHER_ARMOR: true
+
+    #Should the Plugin check fish bucket entity data?
+    FISH_BUCKET: true
+
+    #Should the Plugin check suspicious stew effects?
+    SUSPICIOUS_STEW: true
+
+    #Should the Plugin check shulker box contents?
+    SHULKER_BOX: true
+
+    #Should the Plugin check bundle contents?
+    BUNDLE: true
 
 #The protection that a shop should check.
 protect:

--- a/quickshop-common/pom.xml
+++ b/quickshop-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quickshop-hikari</artifactId>
         <groupId>com.ghostchu</groupId>
-        <version>6.3.0.0-SNAPSHOT-4</version>
+        <version>6.3.0.0-SNAPSHOT-5</version>
     </parent>
     <build>
         <plugins>


### PR DESCRIPTION
### Summary

This PR refactors ModernCustomMatcher to use Paper’s Data Component API with a whitelist-based, config-driven comparison strategy.

### Changes

* Updated matcher to store and compare DataComponentType.Valued<?> entries.
* Resolved registry entries safely using the Paper data component registry.
* Implemented whitelist-based matching: only components explicitly enabled in matcher.components are compared.
* Merged previous meta toggles into components using uppercase group keys.
* Explicitly excluded CUSTOM_DATA from comparison to prevent ViaVersion protocol markers from causing mismatches.

### Behavior

Matching now:

1. Handles null safety.
2. Optionally checks material.
3. Optionally checks stack amount.
4. Iterates only over enabled component types.
5. Returns false immediately on the first mismatch.
6. Returns true if all enabled components match.

### Config Structure

All comparisons are configured under matcher.components. Keys can be:

* Direct DataComponentTypeKeys fields (e.g., DAMAGE, LORE, ENCHANTMENTS).
* Group keys that expand internally (e.g., BOOKS, SHULKER_BOX, FIREWORK).

Addresses #2274 