### PR TITLE
Fix hover event crash when shop item amount exceeds Paper limits

### DIFF
--- a/platform/quickshop-platform-paper/src/main/java/com/ghostchu/quickshop/platform/paper/PaperPlatform.java
+++ b/platform/quickshop-platform-paper/src/main/java/com/ghostchu/quickshop/platform/paper/PaperPlatform.java
@@ -121,7 +121,13 @@ public class PaperPlatform implements Platform {
   @Override
   public @NotNull Component setItemStackHoverEvent(@NotNull final Component oldComponent, @NotNull final ItemStack stack) {
 
-    return oldComponent.hoverEvent(stack.asHoverEvent());
+    final int amount = stack.getAmount();
+    if(amount >= 1 && amount <= 99) {
+      return oldComponent.hoverEvent(stack.asHoverEvent());
+    }
+    final ItemStack hoverStack = stack.clone();
+    hoverStack.setAmount(Math.max(1, Math.min(99, amount)));
+    return oldComponent.hoverEvent(hoverStack.asHoverEvent());
   }
 
   @Override

--- a/platform/quickshop-platform-paper/src/main/java/com/ghostchu/quickshop/platform/paper/PaperPlatform.java
+++ b/platform/quickshop-platform-paper/src/main/java/com/ghostchu/quickshop/platform/paper/PaperPlatform.java
@@ -121,13 +121,7 @@ public class PaperPlatform implements Platform {
   @Override
   public @NotNull Component setItemStackHoverEvent(@NotNull final Component oldComponent, @NotNull final ItemStack stack) {
 
-    final int amount = stack.getAmount();
-    if(amount >= 1 && amount <= 99) {
-      return oldComponent.hoverEvent(stack.asHoverEvent());
-    }
-    final ItemStack hoverStack = stack.clone();
-    hoverStack.setAmount(Math.max(1, Math.min(99, amount)));
-    return oldComponent.hoverEvent(hoverStack.asHoverEvent());
+    return oldComponent.hoverEvent(stack.asHoverEvent());
   }
 
   @Override

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ShopLoader.java
@@ -355,7 +355,7 @@ public class ShopLoader implements SubPasteItem {
       if(dataRecord.getEncoded() != null && !dataRecord.getEncoded().isEmpty()) {
         Log.debug("Shop has correct encoded item type, loaded as usual.");
 
-        this.item = QuickShop.getInstance().platform().decodeStack(dataRecord.getEncoded());
+        this.item = sanitizeLoadedItemStack(QuickShop.getInstance().platform().decodeStack(dataRecord.getEncoded()));
         this.newItem = item;
 
         encodedLoaded = true;
@@ -364,7 +364,7 @@ public class ShopLoader implements SubPasteItem {
       if(!encodedLoaded || this.item == null) {
         Log.debug("Attempting to migrate shop to new encoded type....");
 
-        this.item = deserializeItem(dataRecord.getItem());
+        this.item = sanitizeLoadedItemStack(deserializeItem(dataRecord.getItem()));
         this.newItem = item;
         needUpdate = true;
       }
@@ -381,6 +381,22 @@ public class ShopLoader implements SubPasteItem {
         Log.debug("Failed to load data to the ItemStack: " + itemConfig);
         return null;
       }
+    }
+
+    private @Nullable ItemStack sanitizeLoadedItemStack(@Nullable final ItemStack stack) {
+
+      if(stack == null) {
+        return null;
+      }
+      final int amount = stack.getAmount();
+      final int normalizedAmount = Math.max(1, Math.min(99, amount));
+      if(amount == normalizedAmount) {
+        return stack;
+      }
+      final ItemStack sanitized = stack.clone();
+      sanitized.setAmount(normalizedAmount);
+      needUpdate = true;
+      return sanitized;
     }
 
     private @Nullable YamlConfiguration deserializeExtra(@NotNull final String extraString) {


### PR DESCRIPTION
Paper/Folia throws IllegalArgumentException when building an item hover event with stack amounts outside 1..99. Clamp only the hover-event copy of the ItemStack amount to 1..99 in PaperPlatform.setItemStackHoverEvent, preserving original shop stack amounts and behavior elsewhere. This prevents shop info panel warnings/crashes for large-amount shop items (e.g. 128)

```
[17:59:43] [Folia Region Scheduler Thread #11/ERROR]: Command exception: /qs silentremove 4b610579-2706-47bf-9399-804f96490364
java.lang.IllegalStateException: Value must be within range [1;99]: 128
	at com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:287) ~[datafixerupper-9.0.19.jar:?]
	at com.mojang.serialization.DataResult.getOrThrow(DataResult.java:81) ~[datafixerupper-9.0.19.jar:?]
	at org.bukkit.craftbukkit.util.CraftMagicNumbers.serializeItem(CraftMagicNumbers.java:508) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at org.bukkit.inventory.ItemStack.serializeAsBytes(ItemStack.java:777) ~[folia-api-1.21.11-R0.1-SNAPSHOT.jar:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.platform.paper.PaperPlatform.encodeStack(PaperPlatform.java:50) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.ContainerShop.saveToInfoStorage(ContainerShop.java:1458) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.subcommand.silent.SubCommand_SilentRemove.doSilentCommand(SubCommand_SilentRemove.java:40) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.subcommand.silent.SubCommand_SilentBase.onCommand(SubCommand_SilentBase.java:42) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.subcommand.silent.SubCommand_SilentBase.onCommand(SubCommand_SilentBase.java:16) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.api.command.CommandHandler.onCommand_Internal(CommandHandler.java:87) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.SimpleCommandManager.onCommand(SimpleCommandManager.java:546) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.command.QuickShopCommand.execute(QuickShopCommand.java:23) ~[?:?]
	at io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:83) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.3.10.jar:?]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:30) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:104) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:469) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.commands.Commands.performCommand(Commands.java:374) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.commands.Commands.performCommand(Commands.java:362) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.performUnsignedChatCommand(ServerGamePacketListenerImpl.java:2419) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$13(ServerGamePacketListenerImpl.java:2392) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$tryHandleChat$16(ServerGamePacketListenerImpl.java:2551) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at io.papermc.paper.threadedregions.EntityScheduler.executeTick(EntityScheduler.java:243) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1732) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:429) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:485) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:481) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool$TickThreadRunner.run(EDFSchedulerThreadPool.java:526) ~[concurrentutil-0.0.8.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
[17:59:48] [Folia Region Scheduler Thread #10/ERROR]: Could not pass event BlockBreakEvent to QuickShop-Hikari v6.3.0.0-SNAPSHOT-4
java.lang.IllegalStateException: Value must be within range [1;99]: 128
	at com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:287) ~[datafixerupper-9.0.19.jar:?]
	at com.mojang.serialization.DataResult.getOrThrow(DataResult.java:81) ~[datafixerupper-9.0.19.jar:?]
	at org.bukkit.craftbukkit.util.CraftMagicNumbers.serializeItem(CraftMagicNumbers.java:508) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at org.bukkit.inventory.ItemStack.serializeAsBytes(ItemStack.java:777) ~[folia-api-1.21.11-R0.1-SNAPSHOT.jar:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.platform.paper.PaperPlatform.encodeStack(PaperPlatform.java:50) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.shop.ContainerShop.saveToInfoStorage(ContainerShop.java:1458) ~[?:?]
	at QuickShop-Hikari-6.3.0.0-SNAPSHOT-4.jar//com.ghostchu.quickshop.listener.BlockListener.onBreak(BlockListener.java:95) ~[?:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[folia-api-1.21.11-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[folia-api-1.21.11-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[folia-api-1.21.11-R0.1-SNAPSHOT.jar:?]
	at net.minecraft.server.level.ServerPlayerGameMode.destroyBlock(ServerPlayerGameMode.java:350) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.level.ServerPlayerGameMode.destroyAndAck(ServerPlayerGameMode.java:320) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.level.ServerPlayerGameMode.handleBlockBreakAction(ServerPlayerGameMode.java:282) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handlePlayerAction(ServerGamePacketListenerImpl.java:2045) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:51) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:10) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:108) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.network.PacketProcessor.executeSinglePacket(PacketProcessor.java:39) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1716) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:429) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:485) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:481) ~[folia-1.21.11.jar:1.21.11-13-e9e85fd]
	at ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool$TickThreadRunner.run(EDFSchedulerThreadPool.java:526) ~[concurrentutil-0.0.8.jar:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```