### PR TITLE
Fix thread safety in getRemainingStock

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -686,20 +686,39 @@ public class ContainerShop implements Shop, Reloadable {
   @Override
   public int getRemainingStock() {
 
-    if(this.unlimited) {
+    if (this.unlimited) {
       return -1;
     }
-    if(Bukkit.isPrimaryThread()) {
-      if(this.getInventory() == null) {
-        Log.debug("Failed to calc RemainingStock for shop " + this + ": Inventory null.");
+
+    if (Bukkit.getServer().isOwnedByCurrentRegion(location)) {
+
+      if (this.getInventory() == null) {
         return 0;
       }
       final int stock = Util.countItems(this.getInventory(), this);
       new ShopInventoryCalculateEvent(this, -1, stock).callEvent();
       return stock;
-    } else {
-      return plugin.getShopManager().queryShopInventoryCacheInDatabase(this).join().getStock();
     }
+
+    CompletableFuture<Integer> future = new CompletableFuture<>();
+
+    QuickShop.folia()
+        .getScheduler()
+        .runAtLocation(
+            this.location,
+            task -> {
+              if (this.getInventory() == null) {
+                future.complete(0);
+                return;
+              }
+
+              final int stock = Util.countItems(this.getInventory(), this);
+              new ShopInventoryCalculateEvent(this, -1, stock).callEvent();
+
+              future.complete(stock);
+            });
+
+    return future.join();
   }
 
   /**

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -686,13 +686,13 @@ public class ContainerShop implements Shop, Reloadable {
   @Override
   public int getRemainingStock() {
 
-    if (this.unlimited) {
+    if(this.unlimited) {
       return -1;
     }
 
-    if (Bukkit.getServer().isOwnedByCurrentRegion(location)) {
+    if(Bukkit.getServer().isOwnedByCurrentRegion(location)) {
 
-      if (this.getInventory() == null) {
+      if(this.getInventory() == null) {
         return 0;
       }
       final int stock = Util.countItems(this.getInventory(), this);
@@ -703,20 +703,20 @@ public class ContainerShop implements Shop, Reloadable {
     CompletableFuture<Integer> future = new CompletableFuture<>();
 
     QuickShop.folia()
-        .getScheduler()
-        .runAtLocation(
-            this.location,
-            task -> {
-              if (this.getInventory() == null) {
-                future.complete(0);
-                return;
-              }
+      .getScheduler()
+      .runAtLocation(
+        this.location,
+        task->{
+          if(this.getInventory() == null) {
+            future.complete(0);
+            return;
+          }
 
-              final int stock = Util.countItems(this.getInventory(), this);
-              new ShopInventoryCalculateEvent(this, -1, stock).callEvent();
+          final int stock = Util.countItems(this.getInventory(), this);
+          new ShopInventoryCalculateEvent(this, -1, stock).callEvent();
 
-              future.complete(stock);
-            });
+          future.complete(stock);
+        });
 
     return future.join();
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -700,7 +700,7 @@ public class ContainerShop implements Shop, Reloadable {
       return stock;
     }
 
-    CompletableFuture<Integer> future = new CompletableFuture<>();
+    final CompletableFuture<Integer> future = new CompletableFuture<>();
 
     QuickShop.folia()
       .getScheduler()


### PR DESCRIPTION
<!--
Thank you for contributing to QuickShop-Hikari! 
Please complete all relevant sections below before requesting review.
-->

# Type of Change

Please select the type of change this PR represents:

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] hotfix – Urgent production fix
- [ ] refactor – Code improvement (no behavior change)
- [ ] docs – Documentation/config comment changes only
- [ ] chore – Build/tooling/internal maintenance
- [ ] breaking – Breaking change (requires migration)

> If this is a breaking change, clearly describe the migration steps below.

---

# General Contribution Checklist

- [x] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
- [x] My branch name follows the naming conventions in CONTRIBUTING.md.
- [x] I have signed the Contributor License Agreement (CLA), if required.
- [x] My changes are based on the latest `hikari` branch.
- [x] I have tested my changes locally.
- [x] Existing functionality has not been unintentionally broken.

---

# Description of Changes

Fix thread safety in getRemainingStock by scheduling inventory access on correct region.

fix #2294