### PR TITLE
fix: correct stale close message to match 30-day threshold

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -18,7 +18,7 @@ jobs:
             days-before-issue-close: 30
             stale-issue-label: "stale"
             stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
-            close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+            close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
 
             # pull requests
             days-before-pr-stale: -1


### PR DESCRIPTION
<!--
Thank you for contributing to QuickShop-Hikari! 
Please complete all relevant sections below before requesting review.
-->

# Type of Change

Please select the type of change this PR represents:

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] hotfix – Urgent production fix
- [ ] refactor – Code improvement (no behavior change)
- [ ] docs – Documentation/config comment changes only
- [ ] chore – Build/tooling/internal maintenance
- [ ] breaking – Breaking change (requires migration)

> If this is a breaking change, clearly describe the migration steps below.

---

# General Contribution Checklist

- [x] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
- [x] My branch name follows the naming conventions in CONTRIBUTING.md.
- [x] I have signed the Contributor License Agreement (CLA), if required.
- [x] My changes are based on the latest `hikari` branch.
- [x] I have tested my changes locally.
- [x] Existing functionality has not been unintentionally broken.

---

# Description of Changes

Clearly explain:

- What was changed?
  - The `close-issue-message` in `.github/workflows/close-inactive-issues.yml` was updated from "7 days since being marked as stale" to "30 days since being marked as stale".
- Why was it changed?
  - The message previously stated 7 days, but the actual configuration uses `days-before-issue-close: 30`. This inconsistency could confuse issue creators about when an issue will be closed.
- What issue does it solve?
  -Aligns the stale-issue closure message with the actual configured timeout, improving clarity.
- Is this user-facing, developer-facing, or internal?
  - User-facing (issue creators).

---

# Testing Notes

How was this tested?

* [x] Local test server
* [ ] Networked proxy setup
* [ ] With database (MySQL)
* [ ] With H2
* [ ] Other integrations (describe below)

Additional notes: Validated YAML syntax and reviewed workflow logic.

---

# Changelog Entry

### Fix
- Corrected stale-issue close message to reflect the actual 30-day threshold instead of incorrectly stating 7 days. (wunanc)

---

# Maintainer Review Checklist (Internal)
<!--
 Only a member of the QuickShop community maintainer should fill this part out.
-->

* [ ] Code structure meets project standards
* [ ] No unintended side effects
* [ ] Config additions follow style guide
* [ ] Documentation updated (if needed)
* [ ] Changelog entry added
* [ ] Breaking change properly labeled

---

Thank you for contributing to QuickShop-Hikari, it means a lot to us!