### PR TITLE
Remove blocking in AbstractShopManager#registerShop to fix deadlock on Folia

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/AbstractShopManager.java
@@ -472,11 +472,13 @@ public abstract class AbstractShopManager implements ShopManager {
     addShopToLookupTable(shop);
     if(!persist) return CompletableFuture.completedFuture(null);
     return plugin.getDatabaseHelper().createData(shop).thenCompose(plugin.getDatabaseHelper()::createShop)
-            .thenAccept(id->{
+            .thenCompose(id->{
               Log.debug("DEBUG: Setting shop id");
               shop.setShopId(id);
               Log.debug("DEBUG: Creating shop map");
-              plugin.getDatabaseHelper().createShopMap(id, shop.getLocation()).join();
+              return plugin.getDatabaseHelper().createShopMap(id, shop.getLocation());
+            })
+            .thenAccept(v->{
               Log.debug("DEBUG: Creating shop successfully");
               shop.setDirty();
 


### PR DESCRIPTION
<!--
Thank you for contributing to QuickShop-Hikari! 
Please complete all relevant sections below before requesting review.
-->

# Type of Change

Please select the type of change this PR represents:

- [ ] feat – New feature
- [x] fix – Bug fix
- [ ] hotfix – Urgent production fix
- [ ] refactor – Code improvement (no behavior change)
- [ ] docs – Documentation/config comment changes only
- [ ] chore – Build/tooling/internal maintenance
- [ ] breaking – Breaking change (requires migration)

> If this is a breaking change, clearly describe the migration steps below.

---

# General Contribution Checklist

- [x] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
- [x] My branch name follows the naming conventions in CONTRIBUTING.md.
- [x] I have signed the Contributor License Agreement (CLA), if required.
- [x] My changes are based on the latest `hikari` branch.
- [x] I have tested my changes locally.
- [x] Existing functionality has not been unintentionally broken.

---

# Description of Changes

Fixes a deadlock that can occur when two players create a shop at the exact same time, which is currently only possible on Folia across different regions. The cause behind it was that the future that was being waited on was scheduled to be executed on the same threads that were busy waiting on it to finish, causing the deadlock and preventing any other database operations from working.

---

# Testing Notes

How was this tested?

* [x] Local test server
* [ ] Networked proxy setup
* [x] With database (MySQL)
* [ ] With H2
* [ ] Other integrations (describe below)

Additional notes:
None

---

# Changelog Entry

```markdown
### Fix
- Remove blocking in AbstractShopManager#registerShop to fix deadlock on Folia. (Warrior)
```

---

# Maintainer Review Checklist (Internal)
<!--
 Only a member of the QuickShop community maintainer should fill this part out.
-->

* [ ] Code structure meets project standards
* [ ] No unintended side effects
* [ ] Config additions follow style guide
* [ ] Documentation updated (if needed)
* [ ] Changelog entry added
* [ ] Breaking change properly labeled

---