### PR TITLE
Fix: Process `queryShopInventoryCacheInDatabase` without blocking

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
@@ -10,6 +10,7 @@ import com.ghostchu.quickshop.util.MsgUtil;
 import com.ghostchu.quickshop.util.Util;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -108,7 +109,7 @@ public class SubCommand_Find implements CommandHandler<Player> {
            && plugin.getItemMarker().get(originLookFor) == null) {
           continue;
         }
-        if(excludeOutOfStock) {
+        if(excludeOutOfStock && Bukkit.getServer().isOwnedByCurrentRegion(shop.getLocation())) {
           if((shop.isSelling() && shop.getRemainingStock() == 0) || (shop.isBuying() && shop.getRemainingSpace() == 0)) {
             continue;
           }
@@ -146,16 +147,19 @@ public class SubCommand_Find implements CommandHandler<Player> {
         previewComponentPrePopulateEvent.callEvent();
         previewItemStack = previewComponentPrePopulateEvent.getItemStack();
 
-        Component entryComponent = plugin.text().of(sender, "nearby-shop-entry",
-                                                    shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(1),
-                                                    shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(3),
-                                                    location.getBlockX(),
-                                                    location.getBlockY(),
-                                                    location.getBlockZ(),
-                                                    shopDoubleEntry.getValue().intValue()
-                                                   ).forLocale();
-        entryComponent = plugin.platform().setItemStackHoverEvent(entryComponent, previewItemStack);
-        MsgUtil.sendDirectMessage(sender, entryComponent);
+        final ItemStack finalPreviewItemStack = previewItemStack;
+        QuickShop.folia().getScheduler().runAtLocation(location, task -> {
+          Component entryComponent = plugin.text().of(sender, "nearby-shop-entry",
+                                                      shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(1),
+                                                      shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(3),
+                                                      location.getBlockX(),
+                                                      location.getBlockY(),
+                                                      location.getBlockZ(),
+                                                      shopDoubleEntry.getValue().intValue()
+                                                     ).forLocale();
+          entryComponent = plugin.platform().setItemStackHoverEvent(entryComponent, finalPreviewItemStack);
+          MsgUtil.sendDirectMessage(sender, entryComponent);
+        });
       }
 
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/command/subcommand/SubCommand_Find.java
@@ -10,7 +10,6 @@ import com.ghostchu.quickshop.util.MsgUtil;
 import com.ghostchu.quickshop.util.Util;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -109,7 +108,7 @@ public class SubCommand_Find implements CommandHandler<Player> {
            && plugin.getItemMarker().get(originLookFor) == null) {
           continue;
         }
-        if(excludeOutOfStock && Bukkit.getServer().isOwnedByCurrentRegion(shop.getLocation())) {
+        if(excludeOutOfStock) {
           if((shop.isSelling() && shop.getRemainingStock() == 0) || (shop.isBuying() && shop.getRemainingSpace() == 0)) {
             continue;
           }
@@ -147,19 +146,16 @@ public class SubCommand_Find implements CommandHandler<Player> {
         previewComponentPrePopulateEvent.callEvent();
         previewItemStack = previewComponentPrePopulateEvent.getItemStack();
 
-        final ItemStack finalPreviewItemStack = previewItemStack;
-        QuickShop.folia().getScheduler().runAtLocation(location, task -> {
-          Component entryComponent = plugin.text().of(sender, "nearby-shop-entry",
-                                                      shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(1),
-                                                      shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(3),
-                                                      location.getBlockX(),
-                                                      location.getBlockY(),
-                                                      location.getBlockZ(),
-                                                      shopDoubleEntry.getValue().intValue()
-                                                     ).forLocale();
-          entryComponent = plugin.platform().setItemStackHoverEvent(entryComponent, finalPreviewItemStack);
-          MsgUtil.sendDirectMessage(sender, entryComponent);
-        });
+        Component entryComponent = plugin.text().of(sender, "nearby-shop-entry",
+                                                    shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(1),
+                                                    shop.getSignText(plugin.text().findRelativeLanguages(sender)).get(3),
+                                                    location.getBlockX(),
+                                                    location.getBlockY(),
+                                                    location.getBlockZ(),
+                                                    shopDoubleEntry.getValue().intValue()
+                                                   ).forLocale();
+        entryComponent = plugin.platform().setItemStackHoverEvent(entryComponent, previewItemStack);
+        MsgUtil.sendDirectMessage(sender, entryComponent);
       }
 
     }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -699,12 +699,19 @@ public class ContainerShop implements Shop, Reloadable {
       return stock;
     }
 
-    // Off-region: cannot read the inventory synchronously without
-    // blocking the calling region thread (Folia watchdog kills the tick
-    // after ~10s and it risks a deadlock if the owning region is itself
-    // waiting on us).  Callers iterating shops across regions must wrap
-    // this in QuickShop.folia().getScheduler().runAtLocation(...) - see
-    // SubCommand_Info for the established pattern.
+    QuickShop.folia()
+      .getScheduler()
+      .runAtLocation(
+        this.location,
+        task->{
+          if(this.getInventory() == null) {
+            return;
+          }
+
+          final int stock = Util.countItems(this.getInventory(), this);
+          new ShopInventoryCalculateEvent(this, -1, stock).callEvent();
+        });
+
     return 0;
   }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -31,6 +31,7 @@ import com.ghostchu.quickshop.api.shop.IShopType;
 import com.ghostchu.quickshop.api.shop.Shop;
 import com.ghostchu.quickshop.api.shop.ShopInfoStorage;
 import com.ghostchu.quickshop.api.shop.ShopType;
+import com.ghostchu.quickshop.api.shop.cache.ShopInventoryCountCache;
 import com.ghostchu.quickshop.api.shop.display.DisplayType;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermission;
 import com.ghostchu.quickshop.api.shop.permission.BuiltInShopPermissionGroup;
@@ -41,7 +42,6 @@ import com.ghostchu.quickshop.obj.QUserImpl;
 import com.ghostchu.quickshop.shop.datatype.ShopSignPersistentDataType;
 import com.ghostchu.quickshop.shop.display.AbstractDisplayItem;
 import com.ghostchu.quickshop.util.MsgUtil;
-import com.ghostchu.quickshop.util.PackageUtil;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.logger.Log;
 import com.ghostchu.quickshop.util.logging.container.ShopRemoveLog;
@@ -672,9 +672,12 @@ public class ContainerShop implements Shop, Reloadable {
       new ShopInventoryCalculateEvent(this, space, -1).callEvent();
       Log.debug("Space count is: " + space);
       return space;
-    }
+    } else {
 
-    return 0;
+      return plugin.getShopManager().queryShopInventoryCacheInDatabase(this)
+            .thenApply(ShopInventoryCountCache::getSpace)
+            .getNow(0);
+    }
   }
 
   /**
@@ -699,20 +702,25 @@ public class ContainerShop implements Shop, Reloadable {
       return stock;
     }
 
+    final CompletableFuture<Integer> future = new CompletableFuture<>();
+
     QuickShop.folia()
       .getScheduler()
       .runAtLocation(
         this.location,
         task->{
           if(this.getInventory() == null) {
+            future.complete(0);
             return;
           }
 
           final int stock = Util.countItems(this.getInventory(), this);
           new ShopInventoryCalculateEvent(this, -1, stock).callEvent();
+
+          future.complete(stock);
         });
 
-    return 0;
+    return future.getNow(0);
   }
 
   /**

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/ContainerShop.java
@@ -661,7 +661,7 @@ public class ContainerShop implements Shop, Reloadable {
       return -1;
     }
 
-    if(Bukkit.isPrimaryThread()) {
+    if(Bukkit.getServer().isOwnedByCurrentRegion(location)) {
 
       if(this.getInventory() == null) {
         Log.debug("Failed to calc RemainingSpace for shop " + this + ": Inventory null.");
@@ -672,10 +672,9 @@ public class ContainerShop implements Shop, Reloadable {
       new ShopInventoryCalculateEvent(this, space, -1).callEvent();
       Log.debug("Space count is: " + space);
       return space;
-    } else {
-
-      return plugin.getShopManager().queryShopInventoryCacheInDatabase(this).join().getSpace();
     }
+
+    return 0;
   }
 
   /**
@@ -700,25 +699,13 @@ public class ContainerShop implements Shop, Reloadable {
       return stock;
     }
 
-    final CompletableFuture<Integer> future = new CompletableFuture<>();
-
-    QuickShop.folia()
-      .getScheduler()
-      .runAtLocation(
-        this.location,
-        task->{
-          if(this.getInventory() == null) {
-            future.complete(0);
-            return;
-          }
-
-          final int stock = Util.countItems(this.getInventory(), this);
-          new ShopInventoryCalculateEvent(this, -1, stock).callEvent();
-
-          future.complete(stock);
-        });
-
-    return future.join();
+    // Off-region: cannot read the inventory synchronously without
+    // blocking the calling region thread (Folia watchdog kills the tick
+    // after ~10s and it risks a deadlock if the owning region is itself
+    // waiting on us).  Callers iterating shops across regions must wrap
+    // this in QuickShop.folia().getScheduler().runAtLocation(...) - see
+    // SubCommand_Info for the established pattern.
+    return 0;
   }
 
   /**


### PR DESCRIPTION
On Folia, we may run into: https://mclo.gs/HnnDZpy (Proof of issue)

This is problematic since there's a decent chance that waiting for a response may inevitably result in a full-fledged region deadlock (which occurred on this production instance).