### PR TITLE
Remove the protocollib requirement for per player shop signs

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -789,6 +789,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     } catch(final Exception e) {
       logger.warn("Failed to process virtual display item system", e);
     }
+    loadSignHooker();
     //Load the database
     try(final PerfMonitor ignored = new PerfMonitor("Initialize database")) {
       initDatabase();
@@ -904,19 +905,9 @@ public class QuickShop implements QuickShopAPI, Reloadable {
         try {
 
           virtualDisplayItemManager = new VirtualDisplayItemManager(this);
-          if(getConfig().getBoolean("shop.per-player-shop-sign")) {
-
-            //TODO: Revamp sign system.
-            signHooker = new SignHooker(this);
-            logger.info("Successfully registered per-player shop sign!");
-          } else {
-
-            signHooker = null;
-          }
         } catch(final Exception e) {
 
           //disable displays since we don't have packet support
-          signHooker = null;
           this.display = false;
           getConfig().set("shop.display-items", false);
           javaPlugin.saveConfig();
@@ -925,6 +916,18 @@ public class QuickShop implements QuickShopAPI, Reloadable {
           throw e;
         }
       }
+    }
+  }
+
+  private void loadSignHooker() {
+    if(getConfig().getBoolean("shop.per-player-shop-sign")) {
+
+      signHooker = new SignHooker(this);
+      signHooker.register();
+      logger.info("Successfully registered per-player shop sign!");
+    } else {
+
+      signHooker = null;
     }
   }
 
@@ -1283,7 +1286,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     }
     if(this.signHooker != null) {
 
-      this.signHooker.unload();
+      this.signHooker.unregister();
       logger.info("Unload SignHooker module successfully!");
     }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/sign/SignHooker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/sign/SignHooker.java
@@ -1,79 +1,38 @@
 package com.ghostchu.quickshop.shop.sign;
 
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.ProtocolManager;
-import com.comphenix.protocol.events.ListenerPriority;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.reflect.StructureModifier;
 import com.ghostchu.quickshop.QuickShop;
 import com.ghostchu.quickshop.api.shop.Shop;
+import com.ghostchu.quickshop.listener.AbstractQSListener;
 import com.ghostchu.quickshop.util.Util;
 import com.ghostchu.quickshop.util.logger.Log;
+import io.papermc.paper.event.packet.PlayerChunkLoadEvent;
 import net.kyori.adventure.text.Component;
-import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Sign;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
+import org.bukkit.event.EventHandler;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public class SignHooker {
-
-  private final QuickShop PLUGIN;
-  private final ProtocolManager PROTOCOL_MANAGER = ProtocolLibrary.getProtocolManager();
-  private PacketAdapter chunkAdapter;
+public class SignHooker extends AbstractQSListener {
 
   public SignHooker(final QuickShop plugin) {
-
-    PLUGIN = plugin;
-    registerListener();
+    super(plugin);
   }
 
-  public void registerListener() {
+  @EventHandler
+  public void onPlayerChunkLoadEvent(final PlayerChunkLoadEvent event) {
+    final Player player = event.getPlayer();
+    final Chunk chunk = event.getChunk();
 
-    chunkAdapter = new PacketAdapter(PLUGIN.getJavaPlugin(), ListenerPriority.HIGH, PacketType.Play.Server.MAP_CHUNK) {
-      @Override
-      public void onPacketSending(@NotNull final PacketEvent event) {
-        //is really full chunk data
-        //In 1.17, this value was removed, so read safely
-        final Boolean boxedIsFull = event.getPacket().getBooleans().readSafely(0);
-        final boolean isFull = boxedIsFull == null || boxedIsFull;
-        if(!isFull) {
-          return;
-        }
-        final Player player = event.getPlayer();
-        if(player == null || !player.isOnline()) {
-          return;
-        }
-        if(player.getClass().getName().contains("TemporaryPlayer")) {
-          return;
-        }
-        final StructureModifier<Integer> integerStructureModifier = event.getPacket().getIntegers();
-        //chunk x
-        final int x = integerStructureModifier.read(0);
-        //chunk z
-        final int z = integerStructureModifier.read(1);
-
-        final Map<Location, Shop> shops = PLUGIN.getShopManager().getShops(player.getWorld().getName(), x, z);
-        if(shops == null) {
-
-          return;
-        }
-        shops.forEach((loc, shop)->
-          QuickShop.folia().getScheduler().runAtLocationLater(loc, ()->updatePerPlayerShopSign(player, loc, shop), 2)
-        );
-      }
-    };
-
-    PROTOCOL_MANAGER.addPacketListener(chunkAdapter);
-    Log.debug("SignHooker chunk adapter registered.");
+    final Map<Location, Shop> shops = plugin.getShopManager().getShops(player.getWorld().getName(), chunk.getX(), chunk.getZ());
+    if (shops != null) {
+      shops.forEach((loc, shop)->updatePerPlayerShopSign(player, loc, shop));
+    }
   }
 
   public void updatePerPlayerShopSign(final Player player, final Location location, final Shop shop) {
@@ -82,24 +41,11 @@ public class SignHooker {
     if(!shop.isLoaded()) {
       return;
     }
-    if(!Util.isLoaded(location)) {
-      return;
-    }
     Log.debug("Updating per-player packet sign: Player=" + player.getName() + ", Location=" + location + ", Shop=" + shop.getShopId());
-    final List<Component> lines = shop.getSignText(PLUGIN.getTextManager().findRelativeLanguages(player));
+    final List<Component> lines = shop.getSignText(plugin.getTextManager().findRelativeLanguages(player));
     for(final Sign sign : shop.getSigns()) {
 
-      PLUGIN.platform().sendSignTextChange(player, sign, PLUGIN.getConfig().getBoolean("shop.sign-glowing"), lines);
-    }
-  }
-
-  public void unload() {
-
-    if(PROTOCOL_MANAGER == null) {
-      return;
-    }
-    if(this.chunkAdapter != null) {
-      PROTOCOL_MANAGER.removePacketListener(chunkAdapter);
+      plugin.platform().sendSignTextChange(player, sign, plugin.getConfig().getBoolean("shop.sign-glowing"), lines);
     }
   }
 
@@ -109,13 +55,11 @@ public class SignHooker {
     if(world == null) {
       return;
     }
-    QuickShop.folia().getScheduler().runAtLocation(shop.getLocation(), (loc)->{
-      final Collection<Entity> nearbyPlayers = world.getNearbyEntities(shop.getLocation(), Bukkit.getViewDistance() * 16, shop.getLocation().getWorld().getMaxHeight(), Bukkit.getViewDistance() * 16);
-      for(final Entity nearbyPlayer : nearbyPlayers) {
-        if(nearbyPlayer instanceof final Player player) {
-          updatePerPlayerShopSign(player, location, shop);
-        }
+    QuickShop.folia().getScheduler().runAtLocationLater(shop.getLocation(), ()->{
+      final Collection<Player> nearbyPlayers = world.getPlayersSeeingChunk(shop.getLocation().getBlockX() >> 4, shop.getLocation().getBlockZ() >> 4);
+      for(final Player nearbyPlayer : nearbyPlayers) {
+        updatePerPlayerShopSign(nearbyPlayer, location, shop);
       }
-    });
+    }, 1);
   }
 }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/sign/SignHooker.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/sign/SignHooker.java
@@ -56,10 +56,34 @@ public class SignHooker extends AbstractQSListener {
       return;
     }
     QuickShop.folia().getScheduler().runAtLocationLater(shop.getLocation(), ()->{
-      final Collection<Player> nearbyPlayers = world.getPlayersSeeingChunk(shop.getLocation().getBlockX() >> 4, shop.getLocation().getBlockZ() >> 4);
+      final Collection<Player> nearbyPlayers = getPlayersTrackingChunk(world, shop.getLocation());
       for(final Player nearbyPlayer : nearbyPlayers) {
         updatePerPlayerShopSign(nearbyPlayer, location, shop);
       }
     }, 1);
+  }
+
+  private static final boolean CAN_USE_PLAYERS_SEEING_CHUNK;
+
+  // getPlayersSeeingChunk was added in 1.20.6, so check for the existence of the method and fallback to a worse method on earlier versions.
+  static {
+
+    boolean exists = false;
+    try {
+      //noinspection ConstantValue
+      exists = World.class.getMethod("getPlayersSeeingChunk", int.class, int.class) != null;
+    } catch (ReflectiveOperationException ignored) {}
+
+    CAN_USE_PLAYERS_SEEING_CHUNK = exists;
+  }
+
+  private Collection<Player> getPlayersTrackingChunk(final World world, final Location locationForChunk) {
+
+    if (CAN_USE_PLAYERS_SEEING_CHUNK) {
+      return world.getPlayersSeeingChunk(locationForChunk.getBlockX() >> 4, locationForChunk.getBlockZ() >> 4);
+    } else {
+      final int viewDistanceBlocks = plugin.getJavaPlugin().getServer().getViewDistance() * 16;
+      return world.getNearbyEntitiesByType(Player.class, locationForChunk, viewDistanceBlocks, world.getMaxHeight(), viewDistanceBlocks);
+    }
   }
 }

--- a/quickshop-bukkit/src/main/resources/config.yml
+++ b/quickshop-bukkit/src/main/resources/config.yml
@@ -491,7 +491,6 @@ shop:
 
   # [BETA] Per-player shop sign translations (i18n).
   # Sends an extra sign packet so each player sees text in their own locale.
-  # Requires ProtocolLib.
   per-player-shop-sign: false
 
   # /quickshop find Settings


### PR DESCRIPTION
<!--
Thank you for contributing to QuickShop-Hikari! 
Please complete all relevant sections below before requesting review.
-->

# Type of Change

Please select the type of change this PR represents:

- [x] feat – New feature
- [ ] fix – Bug fix
- [ ] hotfix – Urgent production fix
- [ ] refactor – Code improvement (no behavior change)
- [ ] docs – Documentation/config comment changes only
- [ ] chore – Build/tooling/internal maintenance
- [ ] breaking – Breaking change (requires migration)

> If this is a breaking change, clearly describe the migration steps below.

---

# General Contribution Checklist

- [x] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
- [x] My branch name follows the naming conventions in CONTRIBUTING.md.
- [x] I have signed the Contributor License Agreement (CLA), if required.
- [x] My changes are based on the latest `hikari` branch.
- [x] I have tested my changes locally.
- [x] Existing functionality has not been unintentionally broken.

---

# Description of Changes

Removes the requirement of having protocollib installed to use the per player shop sign option. ~~Opened as a draft since this technically still requires 1.20.6 and up due to the usage of the getPlayersSeeingChunk method.~~ Pre-1.20.6 compatibility has been added & tested

---

# Configuration Changes (if applicable)

If this PR modifies config.yml or another configuration file or adds new configuration options:

- [x] All new config entries follow [CONFIG-STYLE.md](.contributing/config-style.md).
- [x] Comments follow the required structure:
  - Plain-English purpose
  - Behavior details (if needed)
  - Advanced notes (if applicable)
  - Warnings (if applicable)
- [x] Section placement follows the defined ordering rules.
- [x] Defaults favor safety and stability.
- [x] Risky settings include `WARNING:` comments and mitigation guidance.
- [x] Deprecated keys (if any) are clearly marked and documented.
- [x] No existing config defaults were changed unintentionally.

If config changes were made, explain them:

Removed a comment saying it required protocollib

---

# Migration Notes (Required for breaking changes)

None

---

# Related Issues / References

* Fixes: #___
* Relates to: #___
* Documentation PR: #___

---

# Testing Notes

How was this tested?

* [x] Local test server
* [ ] Networked proxy setup
* [x] With database (MySQL)
* [ ] With H2
* [ ] Other integrations (describe below)

Additional notes:
None
---

# Changelog Entry

```markdown
- The per-player-shop-sign option no longer requires ProtocolLib. (Warriorrr)
```

---

# Maintainer Review Checklist (Internal)
<!--
 Only a member of the QuickShop community maintainer should fill this part out.
-->

* [ ] Code structure meets project standards
* [ ] No unintended side effects
* [ ] Config additions follow style guide
* [ ] Documentation updated (if needed)
* [ ] Changelog entry added
* [ ] Breaking change properly labeled

---