### PR TITLE
Allow players muted through LiteBans to use shops

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/ChatListener.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/listener/ChatListener.java
@@ -17,6 +17,8 @@ import java.time.temporal.ChronoUnit;
  */
 public class ChatListener extends AbstractQSListener {
 
+  private static final String LITEBANS_CANCELLED = "[event cancelled by LiteBans]";
+
   public ChatListener(final QuickShop plugin) {
 
     super(plugin);
@@ -33,9 +35,16 @@ public class ChatListener extends AbstractQSListener {
     if(!plugin.getShopManager().getInteractiveManager().containsKey(e.getPlayer().getUniqueId())) {
       return;
     }
+
+    String message = e.getMessage();
+    // Support for LiteBans muted players
+    if (message.startsWith(LITEBANS_CANCELLED)) {
+      message = message.substring(LITEBANS_CANCELLED.length());
+    }
+
     try(PerfMonitor ignored = new PerfMonitor("HandleChat", Duration.of(3, ChronoUnit.SECONDS))) {
       // Fix stupid chat plugin will add a weird space before or after the number we want.
-      plugin.getShopManager().handleChat(e.getPlayer(), e.getMessage().trim());
+      plugin.getShopManager().handleChat(e.getPlayer(), message.trim());
     }
     e.setCancelled(true);
   }


### PR DESCRIPTION
<!--
Thank you for contributing to QuickShop-Hikari! 
Please complete all relevant sections below before requesting review.
-->

# Type of Change

Please select the type of change this PR represents:

- [x] feat – New feature

---

# General Contribution Checklist

- [x] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
- [x] My branch name follows the naming conventions in CONTRIBUTING.md.
- [x] I have signed the Contributor License Agreement (CLA), if required.
- [x] My changes are based on the latest `hikari` branch.
- [x] I have tested my changes locally.
- [x] Existing functionality has not been unintentionally broken.

---

# Description of Changes

This PR adds better compatibility with LiteBans, when a player is muted through that plugin it modifies the chat event to add this string in front of every message, which prevents the muted player from using shops.

---

# Related Issues / References

* Fixes: #___
* Relates to: #___
* Documentation PR: #___

---

# Testing Notes

How was this tested?

* [x] Local test server
* [ ] Networked proxy setup
* [x] With database (MySQL)
* [ ] With H2
* [ ] Other integrations (describe below)

Additional notes:

---

# Changelog Entry

```markdown
### Feature
- Allow players muted through LiteBans to use shops. (Warriorrr)
```

---

# Maintainer Review Checklist (Internal)
<!--
 Only a member of the QuickShop community maintainer should fill this part out.
-->

* [ ] Code structure meets project standards
* [ ] No unintended side effects
* [ ] Config additions follow style guide
* [ ] Documentation updated (if needed)
* [ ] Changelog entry added
* [ ] Breaking change properly labeled

---