### PR TITLE
Fix shop stock notifications to staff using the shop owner's locale

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -99,6 +99,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 /**
  * Manage a lot of shops.
@@ -449,30 +450,21 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
   private void notifySold(@NotNull final QUser buyerQUser, @NotNull final Shop shop, final int amount, final int space) {
 
     Util.asyncThreadRun(()->{
-      final String langCode = plugin.text().findRelativeLanguages(buyerQUser, true).getLocale();
-      final List<Component> sendList = new ArrayList<>();
-      Component notify = plugin.text().of("player-sold-to-your-store", buyerQUser.getDisplay(), amount, Util.getItemStackName(shop.getItem())).forLocale(langCode);
-      notify = plugin.platform().setItemStackHoverEvent(notify, shop.getItem());
+      final List<Function<String, Component>> sendList = new ArrayList<>();
+      final Function<String, Component> notify = langCode->plugin.platform().setItemStackHoverEvent(plugin.text().of("player-sold-to-your-store", buyerQUser.getDisplay(), amount, Util.getItemStackName(shop.getItem())).forLocale(langCode), shop.getItem());
       sendList.add(notify);
       if(space == amount) {
-        Component spaceWarn;
+        Function<String, Component> spaceWarn;
         if(shop.getShopName() == null) {
-          spaceWarn = plugin.text().of("shop-out-of-space", shop.bukkitLocation().getBlockX(), shop.bukkitLocation().getBlockY(), shop.bukkitLocation().getBlockZ()).forLocale(langCode);
+          spaceWarn = langCode->plugin.text().of("shop-out-of-space", shop.bukkitLocation().getBlockX(), shop.bukkitLocation().getBlockY(), shop.bukkitLocation().getBlockZ()).forLocale(langCode);
         } else {
-          spaceWarn = plugin.text().of("shop-out-of-space-name", shop.getShopName(), Util.getItemStackName(shop.getItem())).forLocale(langCode);
+          spaceWarn = langCode->plugin.text().of("shop-out-of-space-name", shop.getShopName(), Util.getItemStackName(shop.getItem())).forLocale(langCode);
         }
-        spaceWarn = plugin.platform().setItemStackHoverEvent(spaceWarn, shop.getItem());
+        final Function<String, Component> finalSpaceWarn = spaceWarn;
+        spaceWarn = langCode->plugin.platform().setItemStackHoverEvent(finalSpaceWarn.apply(langCode), shop.getItem());
         sendList.add(spaceWarn);
       }
-      for(final Component component : sendList) {
-        if(sendStockMessageToStaff) {
-          for(final UUID recv : shop.playersCanAuthorize(BuiltInShopPermission.RECEIVE_ALERT)) {
-            MsgUtil.send(shop, recv, component);
-          }
-        } else {
-          MsgUtil.send(shop, shop.getOwner(), component);
-        }
-      }
+      sendStockMessages(shop, sendList);
     });
   }
 
@@ -1180,39 +1172,48 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
   private void notifyBought(@NotNull final QUser seller, @NotNull final Shop shop, final int amount, final int stock, @NotNull final QSEconomyTransaction transaction) {
 
     Util.asyncThreadRun(()->{
-      final String langCode = plugin.text().findRelativeLanguages(shop.getOwner(), true).getLocale();
-      final List<Component> sendList = new ArrayList<>();
-      Component notify;
+      final List<Function<String, Component>> sendList = new ArrayList<>();
+      Function<String, Component> notify;
       final double ownerPayment = transaction.ownerPayment().doubleValue();
       final double tax = transaction.toTax().doubleValue();
       if(plugin.getConfig().getBoolean("show-tax")) {
-        notify = plugin.text().of("player-bought-from-your-store-tax", seller, amount * shop.getItem().getAmount(), Util.getItemStackName(shop.getItem()), this.formatter.format(ownerPayment, shop), this.formatter.format(tax, shop)).forLocale(langCode);
+        notify = langCode->plugin.text().of("player-bought-from-your-store-tax", seller, amount * shop.getItem().getAmount(), Util.getItemStackName(shop.getItem()), this.formatter.format(ownerPayment, shop), this.formatter.format(tax, shop)).forLocale(langCode);
       } else {
-        notify = plugin.text().of("player-bought-from-your-store", seller, amount * shop.getItem().getAmount(), Util.getItemStackName(shop.getItem()), this.formatter.format(ownerPayment, shop)).forLocale(langCode);
+        notify = langCode->plugin.text().of("player-bought-from-your-store", seller, amount * shop.getItem().getAmount(), Util.getItemStackName(shop.getItem()), this.formatter.format(ownerPayment, shop)).forLocale(langCode);
       }
-      notify = plugin.platform().setItemStackHoverEvent(notify, shop.getItem());
+      final Function<String, Component> finalNotify = notify;
+      notify = langCode->plugin.platform().setItemStackHoverEvent(finalNotify.apply(langCode), shop.getItem());
       sendList.add(notify);
       // Transfers the item from A to B
       if(stock == amount) {
-        Component stockWarn;
+        Function<String, Component> stockWarn;
         if(shop.getShopName() == null) {
-          stockWarn = plugin.text().of("shop-out-of-stock", shop.bukkitLocation().getBlockX(), shop.bukkitLocation().getBlockY(), shop.bukkitLocation().getBlockZ(), Util.getItemStackName(shop.getItem())).forLocale(langCode);
+          stockWarn = langCode->plugin.text().of("shop-out-of-stock", shop.bukkitLocation().getBlockX(), shop.bukkitLocation().getBlockY(), shop.bukkitLocation().getBlockZ(), Util.getItemStackName(shop.getItem())).forLocale(langCode);
         } else {
-          stockWarn = plugin.text().of("shop-out-of-stock-name", shop.getShopName(), Util.getItemStackName(shop.getItem())).forLocale(langCode);
+          stockWarn = langCode->plugin.text().of("shop-out-of-stock-name", shop.getShopName(), Util.getItemStackName(shop.getItem())).forLocale(langCode);
         }
-        stockWarn = plugin.platform().setItemStackHoverEvent(stockWarn, shop.getItem());
+        final Function<String, Component> finalStockWarn = stockWarn;
+        stockWarn = langCode->plugin.platform().setItemStackHoverEvent(finalStockWarn.apply(langCode), shop.getItem());
         sendList.add(stockWarn);
       }
-      for(final Component component : sendList) {
-        if(sendStockMessageToStaff) {
-          for(final UUID recv : shop.playersCanAuthorize(BuiltInShopPermission.RECEIVE_ALERT)) {
-            MsgUtil.send(shop, recv, component);
-          }
-        } else {
-          MsgUtil.send(shop, shop.getOwner(), component);
+      sendStockMessages(shop, sendList);
+    });
+  }
+
+  private void sendStockMessages(@NotNull final Shop shop, final List<Function<String, Component>> messages) {
+    if(sendStockMessageToStaff) {
+      for(final UUID recv : shop.playersCanAuthorize(BuiltInShopPermission.RECEIVE_ALERT)) {
+        final String recvLang = plugin.text().findRelativeLanguages(recv, true).getLocale();
+        for(final Function<String, Component> component : messages) {
+          MsgUtil.send(shop, recv, component.apply(recvLang));
         }
       }
-    });
+    } else {
+      final String langCode = plugin.text().findRelativeLanguages(shop.getOwner(), true).getLocale();
+      for(final Function<String, Component> component : messages) {
+        MsgUtil.send(shop, shop.getOwner(), component.apply(langCode));
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
<!--
Thank you for contributing to QuickShop-Hikari! 
Please complete all relevant sections below before requesting review.
-->

# Type of Change

- [x] fix – Bug fix

---

# General Contribution Checklist

- [x] I have read and understood the [CONTRIBUTING.md](.contributing/contributing.md).
- [x] My branch name follows the naming conventions in CONTRIBUTING.md.
- [x] I have signed the Contributor License Agreement (CLA), if required.
- [x] My changes are based on the latest `hikari` branch.
- [x] I have tested my changes locally.
- [x] Existing functionality has not been unintentionally broken.

---

# Description of Changes
Fixes shop stock messages always using the shop owner's locale instead of the staff's own locale.

---

# Related Issues / References

* Fixes: #___
* Relates to: #___
* Documentation PR: #___

---

# Testing Notes

How was this tested?

* [x] Local test server
* [ ] Networked proxy setup
* [x] With database (MySQL)
* [ ] With H2
* [ ] Other integrations (describe below)

Additional notes:

---

# Changelog Entry

```markdown
### Fix
- Shop stock messages sent to staff no longer use the shop owner's locale. (Warriorrr)
```

---

# Maintainer Review Checklist (Internal)
<!--
 Only a member of the QuickShop community maintainer should fill this part out.
-->

* [ ] Code structure meets project standards
* [ ] No unintended side effects
* [ ] Config additions follow style guide
* [ ] Documentation updated (if needed)
* [ ] Changelog entry added
* [ ] Breaking change properly labeled

---