### PR TITLE
Fix space calculations when using custom max stack sizes

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -575,7 +575,7 @@ public class Util {
     } else {
       final ItemStack item = shop.getItem();
       int space = 0;
-      final int itemMaxStackSize = getItemMaxStackSize(item.getType());
+      final int itemMaxStackSize = item.getMaxStackSize();
       for(final ItemStack iStack : inv) {
         if(iStack == null || iStack.getType() == Material.AIR) {
           space += itemMaxStackSize;
@@ -618,7 +618,7 @@ public class Util {
       return ciw.countSpace(input->matcher.matches(item, input));
     } else {
       int space = 0;
-      final int itemMaxStackSize = getItemMaxStackSize(item.getType());
+      final int itemMaxStackSize = item.getMaxStackSize();
       for(final ItemStack iStack : inv) {
         if(iStack == null || iStack.getType() == Material.AIR) {
           space += itemMaxStackSize;


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

Fixes space calculations being wrong when using the custom max stack sizes option, the max stack size that should be taken into account in this method should be the item's actual max stack size rather than the config's.

---

## Type of Change

* [x] Bug fix

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---