### PR TITLE
Use virtual threads for database thread pool

### DIFF
--- a/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/QuickExecutor.java
+++ b/quickshop-common/src/main/java/com/ghostchu/quickshop/common/util/QuickExecutor.java
@@ -32,7 +32,7 @@ public class QuickExecutor {
 
   public static ExecutorService provideHikariCPExecutor() {
 
-    return new ThreadPoolExecutor(2, 8, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    return Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("QuickShop-Database-Worker-", 0).factory());
   }
 
   public static ExecutorService getCommonExecutor() {


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

This PR aims to fix a throughput issue I experienced with this thread pool, where the number of tasks grew faster than it could handle. Due to the queue not having a bound, new threads were actually never being created and the queue would just grow indefinitely. One way to fix this is to just add a bound, but then we need to deal with the scenario of both the queue and thread pool being full or risk losing tasks.

I think virtual threads are a much better solution to this, these tasks are short lived and spend most of their time being blocked, either waiting for a connection from the hikari pool or waiting for a response from the database. Max threads also don't have to be configured anymore, which means that the main thing limiting throughput becomes the pool size/database instead (which is good).

---

## Type of Change

* [x] Feature

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---