### PR TITLE
Fix calendar watcher spamming warnings during long shutdowns

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -1212,6 +1212,9 @@ public class QuickShop implements QuickShopAPI, Reloadable {
   public final void onDisable() {
 
     logger.info("QuickShop is finishing remaining work, this may need a while...");
+    if(calendarWatcher != null) {
+      calendarWatcher.stop();
+    }
     if(sentryErrorReporter != null) {
       logger.info("Shutting down error reporter...");
       sentryErrorReporter.unregister();
@@ -1282,10 +1285,6 @@ public class QuickShop implements QuickShopAPI, Reloadable {
     }
     logger.info("Shutting down scheduled timers...");
     folia.getScheduler().cancelAllTasks();
-    if(calendarWatcher != null) {
-      logger.info("Shutting down event calendar watcher...");
-      calendarWatcher.stop();
-    }
     /* Unload UpdateWatcher */
     if(this.updateWatcher != null) {
       logger.info("Shutting down update watcher...");

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/CalendarWatcher.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/CalendarWatcher.java
@@ -45,6 +45,10 @@ public class CalendarWatcher implements Runnable {
   @Override
   public void run() {
 
+    if(!plugin.getJavaPlugin().isEnabled()) {
+      return;
+    }
+
     final CalendarEvent.CalendarTriggerType type = getAndUpdate();
     Util.mainThreadRun(()->new CalendarEvent(type).callEvent());
   }
@@ -129,8 +133,9 @@ public class CalendarWatcher implements Runnable {
       if(task != null && !task.isCancelled()) {
         task.cancel();
       }
+      task = null;
     } catch(final IllegalStateException ex) {
-      Log.debug("Task already cancelled " + ex.getMessage());
+      Log.debug("Calendar watcher task already cancelled: " + ex.getMessage());
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary

During long or otherwise abnormal shutdowns (i.e. timeouts during shop saving), the calendar watcher task continues trying to schedule tasks since it's shut down quite late, this PR shuts it down at the earliest and adds an additional check inside the task for if the plugin is still enabled or not.

---

## Type of Change

* [x] Bug fix

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---