### PR TITLE
Fix small reload quirks

### DIFF
--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -973,6 +973,7 @@ public class QuickShop implements QuickShopAPI, Reloadable {
 
       final int checkTime = getConfig().getInt("shop.display-check-time");
       if(this.displayAutoDespawnWatcher != null && this.displayAutoDespawnWatcher.getTaskPeriod() == checkTime) {
+        // Don't restart the task if the check time hasn't changed.
         return;
       }
 

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/QuickShop.java
@@ -346,6 +346,9 @@ public class QuickShop implements QuickShopAPI, Reloadable {
   @Getter
   private RegistryManager registry;
 
+  private LockListener shopLockListener;
+  private DisplayProtectionListener displayProtectionListener;
+
   public QuickShop(final QuickShopBukkit javaPlugin, final Logger logger, final Platform platform) {
 
     this.javaPlugin = javaPlugin;
@@ -967,12 +970,21 @@ public class QuickShop implements QuickShopAPI, Reloadable {
   private void registerDisplayAutoDespawn() {
 
     if(this.display && getConfig().getBoolean("shop.display-auto-despawn")) {
-      this.displayAutoDespawnWatcher = new DisplayAutoDespawnWatcher(this);
-      this.displayAutoDespawnWatcher.start(20, getConfig().getInt("shop.display-check-time"));
+
+      final int checkTime = getConfig().getInt("shop.display-check-time");
+      if(this.displayAutoDespawnWatcher != null && this.displayAutoDespawnWatcher.getTaskPeriod() == checkTime) {
+        return;
+      }
+
+      if(this.displayAutoDespawnWatcher == null) {
+        this.displayAutoDespawnWatcher = new DisplayAutoDespawnWatcher(this);
+      }
+
+      this.displayAutoDespawnWatcher.start(20, checkTime);
       logger.warn("Unrecommended use of display-auto-despawn. This feature may have a heavy impact on the server's performance!");
     } else {
       if(this.displayAutoDespawnWatcher != null) {
-        this.displayAutoDespawnWatcher.stop();
+        this.displayAutoDespawnWatcher.unregister();
         this.displayAutoDespawnWatcher = null;
       }
     }
@@ -1056,30 +1068,46 @@ public class QuickShop implements QuickShopAPI, Reloadable {
       } else {
         logger.error("shop.display-items-check-ticks has been set to an invalid value. Please use a value above 3000.");
       }
-      new DisplayProtectionListener(this).register();
+      if(this.displayProtectionListener == null) {
+        this.displayProtectionListener = new DisplayProtectionListener(this);
+        this.displayProtectionListener.register();
+      }
     } else {
-      Util.unregisterListenerClazz(javaPlugin, DisplayProtectionListener.class);
+      if(this.displayProtectionListener != null) {
+        this.displayProtectionListener.unregister();
+        this.displayProtectionListener = null;
+      }
     }
   }
 
   private void registerShopLock() {
 
-    Util.unregisterListenerClazz(javaPlugin, LockListener.class);
     final boolean useShopLock = getConfig().getBoolean("shop.lock");
     if(useShopLock) {
 
-      new LockListener(this).register();
+      if(this.shopLockListener == null) {
+        this.shopLockListener = new LockListener(this);
+        this.shopLockListener.register();
+      }
+    } else if(this.shopLockListener != null) {
+      this.shopLockListener.unregister();
+      this.shopLockListener = null;
     }
   }
 
   private void registerUpdater() {
 
     final boolean updaterEnabled = this.getConfig().getBoolean("updater", true);
-    if(updaterEnabled) {
+    if(updaterEnabled && this.updateManager == null) {
       this.updateManager = new UpdateManager(this);
       updateWatcher = new UpdateWatcher();
       updateWatcher.init();
     } else {
+      if (this.updateManager != null) {
+        this.updateManager.unregister();
+        this.updateManager = null;
+      }
+
       if(updateWatcher != null) {
         updateWatcher.uninit();
         updateWatcher = null;

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/shop/SimpleShopManager.java
@@ -193,7 +193,9 @@ public class SimpleShopManager extends AbstractShopManager implements ShopManage
       }
       cacheUnlimitedShopAccount = QUserImpl.createSync(plugin.getPlayerFinder(), uAccount);
     }
-    this.priceLimiter = new SimplePriceLimiter(plugin);
+    if(this.priceLimiter == null) {
+      this.priceLimiter = new SimplePriceLimiter(plugin);
+    }
     this.useOldCanBuildAlgorithm = plugin.getConfig().getBoolean("limits.old-algorithm");
     this.autoSign = plugin.getConfig().getBoolean("shop.auto-sign");
     this.maximumDigitsLimit = plugin.getConfig().getInt("shop.maximum-digits-in-price", -1);

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/Util.java
@@ -50,8 +50,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
-import org.bukkit.event.HandlerList;
-import org.bukkit.event.Listener;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -59,7 +57,6 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.RegisteredListener;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -1589,21 +1586,6 @@ public class Util {
     final YamlConfiguration cfg = new YamlConfiguration();
     cfg.set("item", iStack);
     return cfg.saveToString();
-  }
-
-  /**
-   * Unregister all listeners registered instances that belong to specified class
-   *
-   * @param plugin Plugin instance
-   * @param clazz  Class to unregister
-   */
-  public static void unregisterListenerClazz(@NotNull final Plugin plugin, @NotNull final Class<? extends Listener> clazz) {
-
-    for(final RegisteredListener registeredListener : HandlerList.getRegisteredListeners(plugin)) {
-      if(registeredListener.getListener().getClass().equals(clazz)) {
-        HandlerList.unregisterAll(registeredListener.getListener());
-      }
-    }
   }
 
   public static boolean checkIfBungee() {

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/updater/UpdateManager.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/util/updater/UpdateManager.java
@@ -71,6 +71,11 @@ public class UpdateManager implements SubPasteItem {
     plugin.getPasteManager().register(plugin.getJavaPlugin(), this);
   }
 
+  public void unregister() {
+
+    this.plugin.getPasteManager().unregister(this.plugin.getJavaPlugin(), this);
+  }
+
   public void registerProvider(@NotNull final UpdateProvider provider) {
     providers.put(provider.id().toLowerCase(Locale.ROOT), provider);
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/DisplayAutoDespawnWatcher.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/DisplayAutoDespawnWatcher.java
@@ -9,6 +9,7 @@ import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.ReloadStatus;
 import com.ghostchu.simplereloadlib.Reloadable;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
+import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -22,6 +23,8 @@ public class DisplayAutoDespawnWatcher implements Runnable, Reloadable, SubPaste
   private final QuickShop plugin;
   private int range;
   private WrappedTask task;
+  @Getter
+  private int taskPeriod;
 
   public DisplayAutoDespawnWatcher(@NotNull final QuickShop plugin) {
 
@@ -50,6 +53,9 @@ public class DisplayAutoDespawnWatcher implements Runnable, Reloadable, SubPaste
   }
 
   public void start(final int delay, final int period) {
+
+    taskPeriod = period;
+    stop();
 
     task = QuickShop.folia().getScheduler().runTimer(this, delay, period);
   }
@@ -97,6 +103,10 @@ public class DisplayAutoDespawnWatcher implements Runnable, Reloadable, SubPaste
       }
     } catch(final IllegalStateException ignore) {
     }
+  }
+
+  public void unregister() {
+    stop();
     plugin.getReloadManager().unregister(this);
     plugin.getPasteManager().unregister(plugin.getJavaPlugin(), this);
   }

--- a/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/UpdateWatcher.java
+++ b/quickshop-bukkit/src/main/java/com/ghostchu/quickshop/watcher/UpdateWatcher.java
@@ -7,9 +7,7 @@ import com.tcoded.folialib.wrapper.task.WrappedTask;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -33,10 +31,7 @@ public class UpdateWatcher implements Listener {
         plugin.logger().info("Update here: https://modrinth.com/plugin/quickshop-hikari");
         for(final Player player : Bukkit.getOnlinePlayers()) {
           if(plugin.perm().hasPermission(player, "quickshop.alerts")) {
-            MsgUtil.sendDirectMessage(player, ChatColor.GREEN + "---------------------------------------------------");
-            MsgUtil.sendDirectMessage(player, ChatColor.GREEN + LegacyComponentSerializer.legacySection().serialize(pickRandomMessage(player)));
-            MsgUtil.sendDirectMessage(player, Component.text("https://modrinth.com/plugin/quickshop-hikari").color(NamedTextColor.AQUA).clickEvent(ClickEvent.openUrl("https://modrinth.com/plugin/quickshop-hikari")));
-            MsgUtil.sendDirectMessage(player, ChatColor.GREEN + "---------------------------------------------------");
+            sendUpdateNotification(player);
           }
         }
       }
@@ -66,11 +61,16 @@ public class UpdateWatcher implements Listener {
       if(!plugin.perm().hasPermission(e.getPlayer(), "quickshop.alerts") || plugin.updateManager().isLatest()) {
         return;
       }
-      MsgUtil.sendDirectMessage(e.getPlayer(), ChatColor.GREEN + "---------------------------------------------------");
-      MsgUtil.sendDirectMessage(e.getPlayer(), ChatColor.GREEN + LegacyComponentSerializer.legacySection().serialize(pickRandomMessage(e.getPlayer())));
-      MsgUtil.sendDirectMessage(e.getPlayer(), ChatColor.AQUA + " https://modrinth.com/plugin/quickshop-hikari");
-      MsgUtil.sendDirectMessage(e.getPlayer(), ChatColor.GREEN + "---------------------------------------------------");
+      sendUpdateNotification(e.getPlayer());
     });
+  }
+
+  private void sendUpdateNotification(final CommandSender sender) {
+
+    MsgUtil.sendDirectMessage(sender, Component.text("---------------------------------------------------", NamedTextColor.GREEN));
+    MsgUtil.sendDirectMessage(sender, pickRandomMessage(sender).color(NamedTextColor.GREEN));
+    MsgUtil.sendDirectMessage(sender, Component.text("https://modrinth.com/plugin/quickshop-hikari", NamedTextColor.AQUA).clickEvent(ClickEvent.openUrl("https://modrinth.com/plugin/quickshop-hikari")));
+    MsgUtil.sendDirectMessage(sender, Component.text("---------------------------------------------------", NamedTextColor.GREEN));
   }
 
   public void uninit() {


### PR DESCRIPTION
<!--
Thanks for contributing to QuickShop-Hikari!
-->

## Summary
Fixes some cases I found where tasks would be doubly registered after reloading, noticed this after the number of reloaded modules would go up after each use of the reload command. (and removes some chatcolor)

---

## Type of Change

* [x] Bug fix

---

## Basic Checks

* [x] I have tested these changes locally
* [x] I confirm no undocumented AI-generated code was used in this submission

---

## Notes (optional)

Add anything important for reviewers:

* Why this change was needed
* Edge cases
* Implementation details

---

## Config Changes (if applicable)

Only fill this out if you touched config:

* Added/changed:
* Default values:
* Any risks or notes:

---

## Breaking Changes (if applicable)

* What changed:
* Required action:

---

## Related (optional)

* Fixes Issue #
* Related to Issue/PR #

---